### PR TITLE
Fix continuous operation of Keithley 2000

### DIFF
--- a/Keithley_2000_Multimeter/Keithley_2000_Multimeter.ini
+++ b/Keithley_2000_Multimeter/Keithley_2000_Multimeter.ini
@@ -6,7 +6,7 @@
 name: Keithley 2000 Multimeter
 
 # The version string should be updated whenever changes are made to this config file
-version: 1.0
+version: 1.1
 
 # Name of folder containing the code defining a custom driver. Do not define this item
 # or leave it blank for any standard driver based on the built-in VISA interface.
@@ -63,7 +63,7 @@ error_cmd: :SYST:ERR?
 
 # Initialization commands are sent to the instrument when starting the driver
 # *RST will reset the device, *CLS clears the interface
-init: TRIG:SOUR IMM; 
+init: :TRIG:SOUR IMM;
 
 # Final commands sent to the instrument when closing the driver
 final: 
@@ -110,10 +110,24 @@ cmd_def_5: "RES"
 cmd_def_6: "FRES"
 set_cmd: :FUNC
 
-[Value]
+[Continuous]
+datatype: BOOLEAN
+def_value: True
+set_cmd: :INIT:CONT
+
+[SingleValue]
 datatype: DOUBLE
 permission: READ
 get_cmd: :READ?
+state_quant: Continuous
+state_value_1: False
+
+[Value]
+datatype: DOUBLE
+permission: READ
+get_cmd: :FETCH?
+state_quant: Continuous
+state_value_1: True
 
 [Auto-zero]
 datatype: BOOLEAN


### PR DESCRIPTION
Added channel to control continuous operation and split "value" channel into "value" and "singleValue" to use :FETCH and :READ for continuous or single-shot operation, respectively. This fixes not being able to
measure if in continuous mode.