### PR TITLE
Additions and fixes to Keithley 2400 driver

### DIFF
--- a/Keithley_2400_SMU/Keithley_2400_SourceMeter.ini
+++ b/Keithley_2400_SMU/Keithley_2400_SourceMeter.ini
@@ -6,7 +6,7 @@
 name: Keithley 2400 SourceMeter
 
 # The version string should be updated whenever changes are made to this config file
-version: 1.0
+version: 1.1
 
 # Name of folder containing the code defining a custom driver. Do not define this item
 # or leave it blank for any standard driver based on the built-in VISA interface.
@@ -104,6 +104,22 @@ cmd_def_2: CURR
 set_cmd: :SOUR:FUNC
 group: Source
 
+[Current limit]
+datatype: DOUBLE
+unit: A
+set_cmd: :SENS:CURR:PROT
+state_quant: Source type
+state_value: Voltage
+group: Source
+
+[Voltage limit]
+datatype: DOUBLE
+unit: V
+set_cmd: :SENS:VOLT:PROT
+state_quant: Source type
+state_value: Current
+group: Source
+
 [Source voltage auto-range]
 datatype: BOOLEAN
 def_value: True
@@ -126,6 +142,7 @@ datatype: DOUBLE
 unit: V
 def_value: 1
 set_cmd: :SOUR:VOLT
+sweep_cmd: ***REPEAT SET***
 state_quant: Source type
 state_value: Voltage
 group: Source
@@ -152,6 +169,7 @@ datatype: DOUBLE
 unit: A
 def_value: 1E-3
 set_cmd: :SOUR:CURR
+sweep_cmd: ***REPEAT SET***
 state_quant: Source type
 state_value: Current
 group: Source
@@ -164,6 +182,7 @@ group: Output
 
 [Measurement type]
 datatype: COMBO
+permission: WRITE
 def_value: Current
 combo_def_1: Voltage
 combo_def_2: Current


### PR DESCRIPTION
- Allow sweeping of sources.
- Channels for source limits ("compliance") added
- Set "Measurement type" to write only. This is just a work around since
the devices responds with different values than used for setting. Some
python code would be needed here.