### PR TITLE
New driver for Lakeshore 33x temperature controllers

### DIFF
--- a/Lakeshore 33x/Lakeshore 33x.ini
+++ b/Lakeshore 33x/Lakeshore 33x.ini
@@ -1,0 +1,195 @@
+# Instrument driver configuration file.
+
+[General settings]
+
+# The name is shown in all the configuration windows
+name: Lakeshore 33x
+
+# The version string should be updated whenever changes are made to this config file
+version: 1.0
+
+# Name of folder containing the code defining a custom driver. Do not define this item
+# or leave it blank for any standard driver based on the built-in VISA interface.
+driver_path:
+
+
+
+[Model and options]
+# The option section allow instruments with different options to use the same driver
+
+# Check instrument model id at startup (True or False). Default is False
+check_model: True
+
+
+model_id_1: MODEL332
+model_id_2: MODEL336
+
+model_str_1: Lakeshore 332
+model_str_2: Lakeshore 336
+
+
+
+# General VISA settings for the instrument.
+[VISA settings]
+
+# Enable or disable communication over the VISA protocol (True or False)
+# If False, the driver will not perform any operations (unless there is a custom driver).
+use_visa = True
+
+# Reset the interface (not the instrument) at startup (True or False).  Default is False
+reset: True
+
+# Time (in seconds) before the timing out while waiting for an instrument response. Default is 5
+timeout: 2
+
+# Query instrument errors (True or False).  If True, every command sent to the device will
+# be followed by an error query.  This is useful when testing new setups, but may degrade
+# performance by slowing down the instrument communication. 
+query_instr_errors: False
+
+# Bit mask for checking status byte errors (default is 255, include all errors)
+# The bits signal the following errors:
+# 0: Operation
+# 1: Request control
+# 2: Query error
+# 3: Device error
+# 4: Execution error
+# 5: Command error
+# 6: User request
+# 7: Power on
+error_bit_mask: 255
+
+# SCPI string to be used when querying for instrument error messages
+error_cmd: 
+
+# Initialization commands are sent to the instrument when starting the driver
+# *RST will reset the device, *CLS clears the interface
+init: 
+
+# Final commands sent to the instrument when closing the driver
+final: 
+
+
+# Define quantities in sections. The section name should be the same as the "name" value
+# The following keywords are allowed:
+#   name:          Quantity name
+#   unit:          Quantity unit
+#   enabled:	   Determines wether the control is enabled from start.  Default is True	
+#   datatype:      The data type should be one of DOUBLE, BOOLEAN, COMBO or STRING
+#   def_value:     Default value
+#   low_lim:       Lowest allowable value.  Defaults to -INF
+#   high_lim:      Highest allowable values.  Defaults to +INF
+#   combo_def_1:   First option in a pull-down combo box. Only used when datatype=COMBO
+#   combo_def_2:   Second option in a pull-down combo box. Only used when datatype=COMBO
+#   ...
+#   combo_def_n:   nth option in a pull-down combo box. Only used when datatype=COMBO
+#   group:         Name of the group where the control belongs.
+#   state_quant:   Quantity that determines this control's visibility
+#   state_value_1: Value of "state_quant" for which the control is visible
+#   state_value_2: Value of "state_quant" for which the control is visible
+#   ...
+#   state_value_n: Value of "state_quant" for which the control is visible
+#   permission:    Sets read/writability, options are BOTH, READ, WRITE or NONE. Default is BOTH 
+#   set_cmd:       Command used to send data to the instrument. Put <*> where the value should appear.
+#   sweep_cmd:     Command used to sweep data. Use <sr> for sweep rate, and <*> for the value.
+#   get_cmd:       Command used to get the data from the instrument. Default is set_cmd?
+
+
+[Temperature A]
+datatype: DOUBLE
+permission: READ
+get_cmd: KRDG? A
+unit: K
+
+[Temperature B]
+datatype: DOUBLE
+permission: READ
+get_cmd: KRDG? B
+unit: K
+
+[Temperature C]
+datatype: DOUBLE
+permission: READ
+get_cmd: KRDG? C
+unit: K
+model_value_1: MODEL336
+
+[Temperature D]
+datatype: DOUBLE
+permission: READ
+get_cmd: KRDG? D
+unit: K
+model_value_1: MODEL336
+
+[Raw A]
+datatype: DOUBLE
+permission: READ
+get_cmd: SRDG? A
+unit: Ohm
+
+[Raw B]
+datatype: DOUBLE
+permission: READ
+get_cmd: SRDG? B
+unit: Ohm
+
+[Raw C]
+datatype: DOUBLE
+permission: READ
+get_cmd: SRDG? C
+unit: Ohm
+model_value_1: MODEL336
+
+[Raw D]
+datatype: DOUBLE
+permission: READ
+get_cmd: SRDG? D
+unit: Ohm
+model_value_1: MODEL336
+
+[Heater]
+datatype: DOUBLE
+permission: READ
+get_cmd: HTR?
+unit: %
+model_value_1: MODEL332
+
+[Heater 1]
+datatype: DOUBLE
+permission: READ
+get_cmd: HTR? 1
+unit: %
+model_value_1: MODEL336
+
+[Heater 2]
+datatype: DOUBLE
+permission: READ
+get_cmd: HTR? 2
+unit: %
+model_value_1: MODEL336
+
+[Setpoint 1]
+datatype: DOUBLE
+get_cmd: SETP? 1
+set_cmd: SETP: 1,
+unit: K
+
+[Setpoint 2]
+datatype: DOUBLE
+get_cmd: SETP? 2
+set_cmd: SETP: 2,
+unit: K
+
+[Setpoint 3]
+datatype: DOUBLE
+get_cmd: SETP? 3
+set_cmd: SETP: 3,
+unit: K
+model_value_1: MODEL336
+
+[Setpoint 4]
+datatype: DOUBLE
+get_cmd: SETP? 4
+set_cmd: SETP: 4,
+unit: K
+model_value_1: MODEL336


### PR DESCRIPTION
New driver for the Lakeshore 332 and 336 temperature controler. The 336 version has not been tested yet.