### PR TITLE
New driver for Lakeshore 475 Gaussmeter

### DIFF
--- a/Lakeshore 475/Lakeshore 475.ini
+++ b/Lakeshore 475/Lakeshore 475.ini
@@ -1,0 +1,139 @@
+# Instrument driver configuration file.
+
+[General settings]
+
+# The name is shown in all the configuration windows
+name: Lakeshore 475
+
+# The version string should be updated whenever changes are made to this config file
+version: 1.0
+
+# Name of folder containing the code defining a custom driver. Do not define this item
+# or leave it blank for any standard driver based on the built-in VISA interface.
+driver_path: Lakeshore 475
+
+
+
+[Model and options]
+# The option section allow instruments with different options to use the same driver
+
+# Check instrument model id at startup (True or False). Default is False
+check_model: True
+
+# List of models supported by this driver
+model_str_1: Lakeshore 475
+
+# Valid model strings returned by the instrument. Default value = model_str
+model_id_1: MODEL475
+
+check_options: True
+option_cmd: UNIT?
+
+option_id_1: 1
+option_id_2: 2
+option_id_3: 3
+option_id_4: 4
+
+option_str_1: Unit Gauss
+option_str_2: Unit Tesla
+option_str_3: Unit Oersted
+option_str_4: Unit A/m
+
+# General VISA settings for the instrument.
+[VISA settings]
+
+# Enable or disable communication over the VISA protocol (True or False)
+# If False, the driver will not perform any operations (unless there is a custom driver).
+use_visa = True
+
+# Reset the interface (not the instrument) at startup (True or False).  Default is False
+reset: True
+
+# Time (in seconds) before the timing out while waiting for an instrument response. Default is 5
+timeout: 2
+
+# Query instrument errors (True or False).  If True, every command sent to the device will
+# be followed by an error query.  This is useful when testing new setups, but may degrade
+# performance by slowing down the instrument communication. 
+query_instr_errors: False
+
+# Bit mask for checking status byte errors (default is 255, include all errors)
+# The bits signal the following errors:
+# 0: Operation
+# 1: Request control
+# 2: Query error
+# 3: Device error
+# 4: Execution error
+# 5: Command error
+# 6: User request
+# 7: Power on
+error_bit_mask: 255
+
+# SCPI string to be used when querying for instrument error messages
+error_cmd: 
+
+# Initialization commands are sent to the instrument when starting the driver
+# *RST will reset the device, *CLS clears the interface
+init:
+
+# Final commands sent to the instrument when closing the driver
+final: 
+
+
+# Define quantities in sections. The section name should be the same as the "name" value
+# The following keywords are allowed:
+#   name:          Quantity name
+#   unit:          Quantity unit
+#   enabled:	   Determines wether the control is enabled from start.  Default is True	
+#   datatype:      The data type should be one of DOUBLE, BOOLEAN, COMBO or STRING
+#   def_value:     Default value
+#   low_lim:       Lowest allowable value.  Defaults to -INF
+#   high_lim:      Highest allowable values.  Defaults to +INF
+#   combo_def_1:   First option in a pull-down combo box. Only used when datatype=COMBO
+#   combo_def_2:   Second option in a pull-down combo box. Only used when datatype=COMBO
+#   ...
+#   combo_def_n:   nth option in a pull-down combo box. Only used when datatype=COMBO
+#   group:         Name of the group where the control belongs.
+#   state_quant:   Quantity that determines this control's visibility
+#   state_value_1: Value of "state_quant" for which the control is visible
+#   state_value_2: Value of "state_quant" for which the control is visible
+#   ...
+#   state_value_n: Value of "state_quant" for which the control is visible
+#   permission:    Sets read/writability, options are BOTH, READ, WRITE or NONE. Default is BOTH 
+#   set_cmd:       Command used to send data to the instrument. Put <*> where the value should appear.
+#   sweep_cmd:     Command used to sweep data. Use <sr> for sweep rate, and <*> for the value.
+#   get_cmd:       Command used to get the data from the instrument. Default is set_cmd?
+
+
+[B-Field Gauss]
+datatype: DOUBLE
+get_cmd: RDGFIELD?
+set_cmd: ANALOG 4,2,0,0,0,5;CSETP <*>
+unit: G
+option_value_1: Unit Gauss
+
+[B-Field Tesla]
+datatype: DOUBLE
+get_cmd: RDGFIELD?
+set_cmd: ANALOG 4,2,0,0,0,5;CSETP <*>
+unit: T
+option_value_1: Unit Tesla
+
+[B-Field Oersted]
+datatype: DOUBLE
+get_cmd: RDGFIELD?
+set_cmd: ANALOG 4,2,0,0,0,5;CSETP <*>
+unit: Oe
+option_value_1: Unit Oersted
+
+[B-Field A/m]
+datatype: DOUBLE
+get_cmd: RDGFIELD?
+set_cmd: ANALOG 4,2,0,0,0,5;CSETP <*>
+unit: A/m
+option_value_1: Unit A/m
+
+[StopThreshold]
+label: Stop when field is near setpoint
+datatype: DOUBLE
+def_value: 0.001

--- a/Lakeshore 475/Lakeshore 475.py
+++ b/Lakeshore 475/Lakeshore 475.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python
+
+import InstrumentDriver
+from VISA_Driver import VISA_Driver
+import visa
+from InstrumentConfig import InstrumentQuantity
+
+__version__ = "0.0.1"
+
+class Error(Exception):
+    pass
+
+class Driver(VISA_Driver):
+    """ This class implements the Lakeshore 475 driver"""
+  
+    def performOpen(self, options={}):
+        """Perform the operation of opening the instrument connection"""
+        VISA_Driver.performOpen(self, options=options)
+        
+
+    def performGetValue(self, quant, options={}):
+        """Perform the Get Value instrument operation"""
+        value = VISA_Driver.performGetValue(self, quant, options)
+        return value
+        
+    def performSetValue(self, quant, value, sweepRate=0.0, options={}):
+        """Perform the set value operation"""
+        # check type of quantity
+        if quant.name[:7] in ('B-Field'):
+            #We do not want the driver to return before the field has reched its target
+            #within the precision selected by the user
+            precision = self.instrCfg.getQuantity('StopThreshold').getValue()
+            self.writeAndLog(quant.set_cmd.replace('<*>', str(value)))
+            diff = abs(float(self.askAndLog("RDGFIELD?")) - value)
+            while diff > precision:
+                self.thread().msleep(100)
+                diff = abs(float(self.askAndLog("RDGFIELD?")) - value)
+            value = float(self.askAndLog("RDGFIELD?"))
+        return value
+        
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
New driver for the Lakeshore 475 magnetometer. When setting a target field, the driver will block until the field is reached within the "StopThreshold".