### PR TITLE
New driver for Zurich Instruments UHF LIAs

### DIFF
--- a/Zurich Instruments UHF/Zurich Instruments UHF.ini
+++ b/Zurich Instruments UHF/Zurich Instruments UHF.ini
@@ -1,0 +1,2207 @@
+# Instrument driver configuration file.
+
+[General settings]
+
+# The name is shown in all the configuration windows
+name: Zurich Instruments UHF
+
+# The version string should be updated whenever changes are made to this config file
+version: 1.0
+
+# Name of folder containing the code defining a custom driver. Do not define this item
+# or leave it blank for any standard driver based on the built-in VISA interface.
+driver_path: Zurich Instruments UHF
+
+
+
+[Model and options]
+# The option section allow instruments with different options to use the same driver
+
+# Check instrument model id at startup (True or False). Default is False
+check_model: False
+
+# List of models supported by this driver
+model_str_1: UHF
+
+check_option: false
+option_str_1: MOD
+
+
+# General VISA settings for the instrument.
+[VISA settings]
+
+# Enable or disable communication over the VISA protocol (True or False)
+# If False, the driver will not perform any operations (unless there is a custom driver).
+use_visa: False
+
+# Define quantities in sections. The section name should be the same as the "name" value
+# The following keywords are allowed:
+#   name:          Quantity name
+#   unit:          Quantity unit
+#   enabled:	   Determines wether the control is enabled from start.  Default is True	
+#   datatype:      The data type should be one of DOUBLE, BOOLEAN, COMBO or STRING
+#   def_value:     Default value
+#   low_lim:       Lowest allowable value.  Defaults to -INF
+#   high_lim:      Highest allowable values.  Defaults to +INF
+#   combo_def_1:   First option in a pull-down combo box. Only used when datatype=COMBO
+#   combo_def_2:   Second option in a pull-down combo box. Only used when datatype=COMBO
+#   ...
+#   combo_def_n:   nth option in a pull-down combo box. Only used when datatype=COMBO
+#   group:         Name of the group where the control belongs.
+#   state_quant:   Quantity that determines this control's visibility
+#   state_value_1: Value of "state_quant" for which the control is visible
+#   state_value_2: Value of "state_quant" for which the control is visible
+#   ...
+#   state_value_n: Value of "state_quant" for which the control is visible
+#   permission:    Sets read/writability, options are BOTH, READ, WRITE or NONE. Default is BOTH 
+#   set_cmd:       Command used to send data to the instrument. Put <*> where the value should appear.
+#   get_cmd:       Command used to get the data from the instrument. Default is set_cmd?
+#   sweep_cmd:     Command used to sweep data. Use <sr> for sweep rate, <st> for sweep time, and <*> for the value.
+#   stop_cmd:      Command used to stop a sweep
+
+
+
+#######################################################################
+### Signal Inputs #####################################################
+#######################################################################
+
+[SigIn1AC]
+label: Input 1 AC Coupling
+datatype: BOOLEAN
+group: Signal Input 1
+section: Signal Input
+get_cmd: /%s/sigins/0/ac
+
+[SigIn1Range]
+label: Input 1 Range
+datatype: DOUBLE
+unit: V
+group: Signal Input 1
+section: Signal Input
+get_cmd: /%s/sigins/0/range
+
+[SigIn2AC]
+label: Input 2 AC Coupling
+datatype: BOOLEAN
+group: Signal Input 2
+section: Signal Input
+get_cmd: /%s/sigins/1/ac
+
+[SigIn2Range]
+label: Input 2 Range
+datatype: DOUBLE
+unit: V
+group: Signal Input 2
+section: Signal Input
+get_cmd: /%s/sigins/1/range
+
+#######################################################################
+### Oscillators #######################################################
+#######################################################################
+
+[Oscillator1Frequency]
+label: Oscillator 1 Frequency
+datatype: DOUBLE
+unit: Hz
+group: Oscillator 1
+section: Oscillator
+get_cmd: /%s/oscs/0/freq
+
+[Oscillator2Frequency]
+label: Oscillator 2 Frequency
+datatype: DOUBLE
+unit: Hz
+group: Oscillator 2
+section: Oscillator
+get_cmd: /%s/oscs/1/freq
+
+[Oscillator3Frequency]
+label: Oscillator 3 Frequency
+datatype: DOUBLE
+unit: Hz
+group: Oscillator 3
+section: Oscillator
+get_cmd: /%s/oscs/2/freq
+
+[Oscillator4Frequency]
+label: Oscillator 4 Frequency
+datatype: DOUBLE
+unit: Hz
+group: Oscillator 4
+section: Oscillator
+get_cmd: /%s/oscs/3/freq
+
+[Oscillator5Frequency]
+label: Oscillator 5 Frequency
+datatype: DOUBLE
+unit: Hz
+group: Oscillator 5
+section: Oscillator
+get_cmd: /%s/oscs/4/freq
+
+[Oscillator6Frequency]
+label: Oscillator 6 Frequency
+datatype: DOUBLE
+unit: Hz
+group: Oscillator 6
+section: Oscillator
+get_cmd: /%s/oscs/5/freq
+
+[Oscillator7Frequency]
+label: Oscillator 7 Frequency
+datatype: DOUBLE
+unit: Hz
+group: Oscillator 7
+section: Oscillator
+get_cmd: /%s/oscs/6/freq
+
+[Oscillator8Frequency]
+label: Oscillator 8 Frequency
+datatype: DOUBLE
+unit: Hz
+group: Oscillator 8
+section: Oscillator
+get_cmd: /%s/oscs/7/freq
+
+
+#######################################################################
+### Signal Outputs ####################################################
+#######################################################################
+
+[SigOut1On]
+label: Signal Out 1 On
+datatype: BOOLEAN
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/on
+
+[Out1SigOut1On]
+label: Output 1 to Signal Out 1
+datatype: BOOLEAN
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/enables/0
+
+[Out1SigOut1Amp]
+label: Amplitude 1 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/amplitudes/0
+
+[Out2SigOut1On]
+label: Output 2 to Signal Out 1
+datatype: BOOLEAN
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/enables/1
+
+[Out2SigOut1Amp]
+label: Amplitude 2 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/amplitudes/1
+
+[Out3SigOut1On]
+label: Output 3 to Signal Out 1
+datatype: BOOLEAN
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/enables/2
+
+[Out3SigOut1Amp]
+label: Amplitude 3 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/amplitudes/2
+
+[Out4SigOut1On]
+label: Output 4 to Signal Out 1
+datatype: BOOLEAN
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/enables/3
+
+[Out4SigOut1Amp]
+label: Amplitude 4 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/amplitudes/3
+
+[Out5SigOut1On]
+label: Output 5 to Signal Out 1
+datatype: BOOLEAN
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/enables/4
+
+[Out5SigOut1Amp]
+label: Amplitude 5 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/amplitudes/4
+
+[Out6SigOut1On]
+label: Output 6 to Signal Out 1
+datatype: BOOLEAN
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/enables/5
+
+[Out6SigOut1Amp]
+label: Amplitude 6 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/amplitudes/5
+
+[Out7SigOut1On]
+label: Output 7 to Signal Out 1
+datatype: BOOLEAN
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/enables/6
+
+[Out7SigOut1Amp]
+label: Amplitude 7 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/amplitudes/6
+
+[Out8SigOut1On]
+label: Output 8 to Signal Out 1
+datatype: BOOLEAN
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/enables/7
+
+[Out8SigOut1Amp]
+label: Amplitude 8 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 1
+section: Signal Output
+get_cmd: /%s/sigouts/0/amplitudes/7
+
+[SigOut2On]
+label: Signal Out 2 On
+datatype: BOOLEAN
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/on
+
+[Out1SigOut2On]
+label: Output 1 to Signal Out 2
+datatype: BOOLEAN
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/enables/0
+
+[Out1SigOut2Amp]
+label: Amplitude 1 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/amplitudes/0
+
+[Out2SigOut2On]
+label: Output 2 to Signal Out 2
+datatype: BOOLEAN
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/enables/1
+
+[Out2SigOut2Amp]
+label: Amplitude 2 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/amplitudes/1
+
+[Out3SigOut2On]
+label: Output 3 to Signal Out 2
+datatype: BOOLEAN
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/enables/2
+
+[Out3SigOut2Amp]
+label: Amplitude 3 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/amplitudes/2
+
+[Out4SigOut2On]
+label: Output 4 to Signal Out 2
+datatype: BOOLEAN
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/enables/3
+
+[Out4SigOut2Amp]
+label: Amplitude 4 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/amplitudes/3
+
+[Out5SigOut2On]
+label: Output 5 to Signal Out 2
+datatype: BOOLEAN
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/enables/4
+
+[Out5SigOut2Amp]
+label: Amplitude 5 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/amplitudes/4
+
+[Out6SigOut2On]
+label: Output 6 to Signal Out 2
+datatype: BOOLEAN
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/enables/5
+
+[Out6SigOut2Amp]
+label: Amplitude 6 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/amplitudes/5
+
+[Out7SigOut2On]
+label: Output 7 to Signal Out 2
+datatype: BOOLEAN
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/enables/6
+
+[Out7SigOut2Amp]
+label: Amplitude 7 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/amplitudes/6
+
+[Out8SigOut2On]
+label: Output 8 to Signal Out 2
+datatype: BOOLEAN
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/enables/7
+
+[Out8SigOut2Amp]
+label: Amplitude 8 (Vpk)
+datatype: DOUBLE
+unit: V
+group: Signal Output 2
+section: Signal Output
+get_cmd: /%s/sigouts/1/amplitudes/7
+
+
+#######################################################################
+### Demodulator read-out channels #####################################
+#######################################################################
+
+[Demod1On]
+label: Demodulator 1 Enabled
+datatype: BOOLEAN
+group: Demodulator 1
+section: Demodulator
+get_cmd: /%s/demods/0/enable
+
+[Demod1X]
+label: Demodulator 1 X
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 1
+section: Demodulator
+get_cmd: /%s/demods/0/sample
+state_quant: Demod1On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod1Y]
+label: Demodulator 1 Y
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 1
+section: Demodulator
+get_cmd: /%s/demods/0/sample
+state_quant: Demod1On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod1R]
+label: Demodulator 1 R
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 1
+section: Demodulator
+get_cmd: /%s/demods/0/sample
+state_quant: Demod1On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod1phi]
+label: Demodulator 1 Phi
+datatype: DOUBLE
+unit: deg
+permission: READ
+group: Demodulator 1
+section: Demodulator
+get_cmd: /%s/demods/0/sample
+state_quant: Demod1On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod2On]
+label: Demodulator 2 Enabled
+datatype: BOOLEAN
+group: Demodulator 2
+section: Demodulator
+get_cmd: /%s/demods/1/enable
+
+[Demod2X]
+label: Demodulator 2 X
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 2
+section: Demodulator
+get_cmd: /%s/demods/1/sample
+state_quant: Demod2On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod2Y]
+label: Demodulator 2 Y
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 2
+section: Demodulator
+get_cmd: /%s/demods/1/sample
+state_quant: Demod2On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod2R]
+label: Demodulator 2 R
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 2
+section: Demodulator
+get_cmd: /%s/demods/1/sample
+state_quant: Demod2On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod2phi]
+label: Demodulator 2 Phi
+datatype: DOUBLE
+unit: deg
+permission: READ
+group: Demodulator 2
+section: Demodulator
+get_cmd: /%s/demods/1/sample
+state_quant: Demod2On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod3On]
+label: Demodulator 3 Enabled
+datatype: BOOLEAN
+group: Demodulator 3
+section: Demodulator
+get_cmd: /%s/demods/2/enable
+
+[Demod3X]
+label: Demodulator 3 X
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 3
+section: Demodulator
+get_cmd: /%s/demods/2/sample
+state_quant: Demod3On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod3Y]
+label: Demodulator 3 Y
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 3
+section: Demodulator
+get_cmd: /%s/demods/2/sample
+state_quant: Demod3On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod3R]
+label: Demodulator 3 R
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 3
+section: Demodulator
+get_cmd: /%s/demods/2/sample
+state_quant: Demod3On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod3phi]
+label: Demodulator 3 Phi
+datatype: DOUBLE
+unit: deg
+permission: READ
+group: Demodulator 3
+section: Demodulator
+get_cmd: /%s/demods/2/sample
+state_quant: Demod3On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod4On]
+label: Demodulator 4 Enabled
+datatype: BOOLEAN
+group: Demodulator 4
+section: Demodulator
+get_cmd: /%s/demods/3/enable
+
+[Demod4X]
+label: Demodulator 4 X
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 4
+section: Demodulator
+get_cmd: /%s/demods/3/sample
+state_quant: Demod4On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod4Y]
+label: Demodulator 4 Y
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 4
+section: Demodulator
+get_cmd: /%s/demods/3/sample
+state_quant: Demod4On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod4R]
+label: Demodulator 4 R
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 4
+section: Demodulator
+get_cmd: /%s/demods/3/sample
+state_quant: Demod4On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod4phi]
+label: Demodulator 4 Phi
+datatype: DOUBLE
+unit: deg
+permission: READ
+group: Demodulator 4
+section: Demodulator
+get_cmd: /%s/demods/3/sample
+state_quant: Demod4On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod5On]
+label: Demodulator 5 Enabled
+datatype: BOOLEAN
+group: Demodulator 5
+section: Demodulator
+get_cmd: /%s/demods/4/enable
+
+[Demod5X]
+label: Demodulator 5 X
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 5
+section: Demodulator
+get_cmd: /%s/demods/4/sample
+state_quant: Demod5On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod5Y]
+label: Demodulator 5 Y
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 5
+section: Demodulator
+get_cmd: /%s/demods/4/sample
+state_quant: Demod5On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod5R]
+label: Demodulator 5 R
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 5
+section: Demodulator
+get_cmd: /%s/demods/4/sample
+state_quant: Demod5On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod5phi]
+label: Demodulator 5 Phi
+datatype: DOUBLE
+unit: deg
+permission: READ
+group: Demodulator 5
+section: Demodulator
+get_cmd: /%s/demods/4/sample
+state_quant: Demod5On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod6On]
+label: Demodulator 6 Enabled
+datatype: BOOLEAN
+group: Demodulator 6
+section: Demodulator
+get_cmd: /%s/demods/5/enable
+
+[Demod6X]
+label: Demodulator 6 X
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 6
+section: Demodulator
+get_cmd: /%s/demods/5/sample
+state_quant: Demod6On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod6Y]
+label: Demodulator 6 Y
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 6
+section: Demodulator
+get_cmd: /%s/demods/5/sample
+state_quant: Demod6On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod6R]
+label: Demodulator 6 R
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 6
+section: Demodulator
+get_cmd: /%s/demods/5/sample
+state_quant: Demod6On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod6phi]
+label: Demodulator 6 Phi
+datatype: DOUBLE
+unit: deg
+permission: READ
+group: Demodulator 6
+section: Demodulator
+get_cmd: /%s/demods/5/sample
+state_quant: Demod6On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod7On]
+label: Demodulator 7 Enabled
+datatype: BOOLEAN
+group: Demodulator 7
+section: Demodulator
+get_cmd: /%s/demods/6/enable
+
+[Demod7X]
+label: Demodulator 7 X
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 7
+section: Demodulator
+get_cmd: /%s/demods/6/sample
+state_quant: Demod7On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod7Y]
+label: Demodulator 7 Y
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 7
+section: Demodulator
+get_cmd: /%s/demods/6/sample
+state_quant: Demod7On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod7R]
+label: Demodulator 7 R
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 7
+section: Demodulator
+get_cmd: /%s/demods/6/sample
+state_quant: Demod7On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod7phi]
+label: Demodulator 7 Phi
+datatype: DOUBLE
+unit: deg
+permission: READ
+group: Demodulator 7
+section: Demodulator
+get_cmd: /%s/demods/6/sample
+state_quant: Demod7On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod8On]
+label: Demodulator 8 Enabled
+datatype: BOOLEAN
+group: Demodulator 8
+section: Demodulator
+get_cmd: /%s/demods/7/enable
+
+[Demod8X]
+label: Demodulator 8 X
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 8
+section: Demodulator
+get_cmd: /%s/demods/7/sample
+state_quant: Demod8On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod8Y]
+label: Demodulator 8 Y
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 8
+section: Demodulator
+get_cmd: /%s/demods/7/sample
+state_quant: Demod8On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod8R]
+label: Demodulator 8 R
+datatype: DOUBLE
+unit: V
+permission: READ
+group: Demodulator 8
+section: Demodulator
+get_cmd: /%s/demods/7/sample
+state_quant: Demod8On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod8phi]
+label: Demodulator 8 Phi
+datatype: DOUBLE
+unit: deg
+permission: READ
+group: Demodulator 8
+section: Demodulator
+get_cmd: /%s/demods/7/sample
+state_quant: Demod8On
+state_value_1: True
+show_in_measurement_dlg: True
+
+
+
+#######################################################################
+### Demodulator settings ##############################################
+#######################################################################
+
+[Demod1Osc]
+label: Demodulator 1 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Demodulator 1
+section: Demodulator
+get_cmd: /%s/demods/0/oscselect
+
+[Demod1RefPhase]
+label: Demodulator 1 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 1
+section: Demodulator
+get_cmd: /%s/demods/0/phaseshift
+
+[Demod1RefPhase]
+label: Demodulator 1 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 1
+section: Demodulator
+get_cmd: /%s/demods/0/phaseshift
+
+[Demod1TC]
+label: Demodulator 1 Time Constant
+datatype: DOUBLE
+unit: s
+group: Demodulator 1
+section: Demodulator
+get_cmd: /%s/demods/0/timeconstant
+
+[Demod2Osc]
+label: Demodulator 2 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Demodulator 2
+section: Demodulator
+get_cmd: /%s/demods/1/oscselect
+
+[Demod2RefPhase]
+label: Demodulator 2 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 2
+section: Demodulator
+get_cmd: /%s/demods/1/phaseshift
+
+[Demod2RefPhase]
+label: Demodulator 2 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 2
+section: Demodulator
+get_cmd: /%s/demods/1/phaseshift
+
+[Demod2TC]
+label: Demodulator 2 Time Constant
+datatype: DOUBLE
+unit: s
+group: Demodulator 2
+section: Demodulator
+get_cmd: /%s/demods/1/timeconstant
+
+[Demod3Osc]
+label: Demodulator 3 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Demodulator 3
+section: Demodulator
+get_cmd: /%s/demods/2/oscselect
+
+[Demod3RefPhase]
+label: Demodulator 3 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 3
+section: Demodulator
+get_cmd: /%s/demods/2/phaseshift
+
+[Demod3RefPhase]
+label: Demodulator 3 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 3
+section: Demodulator
+get_cmd: /%s/demods/2/phaseshift
+
+[Demod3TC]
+label: Demodulator 3 Time Constant
+datatype: DOUBLE
+unit: s
+group: Demodulator 3
+section: Demodulator
+get_cmd: /%s/demods/2/timeconstant
+
+[Demod4Osc]
+label: Demodulator 4 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Demodulator 4
+section: Demodulator
+get_cmd: /%s/demods/3/oscselect
+
+[Demod4RefPhase]
+label: Demodulator 4 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 4
+section: Demodulator
+get_cmd: /%s/demods/3/phaseshift
+
+[Demod4RefPhase]
+label: Demodulator 4 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 4
+section: Demodulator
+get_cmd: /%s/demods/3/phaseshift
+
+[Demod4TC]
+label: Demodulator 4 Time Constant
+datatype: DOUBLE
+unit: s
+group: Demodulator 4
+section: Demodulator
+get_cmd: /%s/demods/3/timeconstant
+
+[Demod5Osc]
+label: Demodulator 5 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Demodulator 5
+section: Demodulator
+get_cmd: /%s/demods/4/oscselect
+
+[Demod5RefPhase]
+label: Demodulator 5 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 5
+section: Demodulator
+get_cmd: /%s/demods/4/phaseshift
+
+[Demod5RefPhase]
+label: Demodulator 5 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 5
+section: Demodulator
+get_cmd: /%s/demods/4/phaseshift
+
+[Demod5TC]
+label: Demodulator 5 Time Constant
+datatype: DOUBLE
+unit: s
+group: Demodulator 5
+section: Demodulator
+get_cmd: /%s/demods/4/timeconstant
+
+[Demod6Osc]
+label: Demodulator 6 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Demodulator 6
+section: Demodulator
+get_cmd: /%s/demods/5/oscselect
+
+[Demod6RefPhase]
+label: Demodulator 6 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 6
+section: Demodulator
+get_cmd: /%s/demods/5/phaseshift
+
+[Demod6RefPhase]
+label: Demodulator 6 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 6
+section: Demodulator
+get_cmd: /%s/demods/5/phaseshift
+
+[Demod6TC]
+label: Demodulator 6 Time Constant
+datatype: DOUBLE
+unit: s
+group: Demodulator 6
+section: Demodulator
+get_cmd: /%s/demods/5/timeconstant
+
+[Demod7Osc]
+label: Demodulator 7 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Demodulator 7
+section: Demodulator
+get_cmd: /%s/demods/6/oscselect
+
+[Demod7RefPhase]
+label: Demodulator 7 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 7
+section: Demodulator
+get_cmd: /%s/demods/6/phaseshift
+
+[Demod7RefPhase]
+label: Demodulator 7 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 7
+section: Demodulator
+get_cmd: /%s/demods/6/phaseshift
+
+[Demod7TC]
+label: Demodulator 7 Time Constant
+datatype: DOUBLE
+unit: s
+group: Demodulator 7
+section: Demodulator
+get_cmd: /%s/demods/6/timeconstant
+
+[Demod8Osc]
+label: Demodulator 8 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Demodulator 8
+section: Demodulator
+get_cmd: /%s/demods/7/oscselect
+
+[Demod8RefPhase]
+label: Demodulator 8 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 8
+section: Demodulator
+get_cmd: /%s/demods/7/phaseshift
+
+[Demod8RefPhase]
+label: Demodulator 8 Reference Phase
+datatype: DOUBLE
+unit: deg
+group: Demodulator 8
+section: Demodulator
+get_cmd: /%s/demods/7/phaseshift
+
+[Demod8TC]
+label: Demodulator 8 Time Constant
+datatype: DOUBLE
+unit: s
+group: Demodulator 8
+section: Demodulator
+get_cmd: /%s/demods/7/timeconstant
+
+#######################################################################
+### Sweeper channels ##################################################
+#######################################################################
+
+[TraceLength]
+label: Trace Length
+datatype: DOUBLE
+unit: s
+section: Trace
+
+[Demod1SampleRate]
+label: Demodulator 1 Sample Rate
+datatype: DOUBLE
+unit: Sa/s
+group: Demodulator 1
+section: Trace
+get_cmd: /%s/demods/0/rate
+
+[TraceDemod1X]
+label: Demodulator 1 X
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 1
+section: Trace
+get_cmd: /%s/demods/0/sample
+state_quant: Demod1On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod1Y]
+label: Demodulator 1 Y
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 1
+section: Trace
+get_cmd: /%s/demods/0/sample
+state_quant: Demod1On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod1R]
+label: Demodulator 1 R
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 1
+section: Trace
+get_cmd: /%s/demods/0/sample
+state_quant: Demod1On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod1phi]
+label: Demodulator 1 Phi
+datatype: VECTOR
+x_unit: s
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 1
+section: Trace
+get_cmd: /%s/demods/0/sample
+state_quant: Demod1On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod2SampleRate]
+label: Demodulator 2 Sample Rate
+datatype: DOUBLE
+unit: Sa/s
+group: Demodulator 2
+section: Trace
+get_cmd: /%s/demods/1/rate
+
+[TraceDemod2X]
+label: Demodulator 2 X
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 2
+section: Trace
+get_cmd: /%s/demods/1/sample
+state_quant: Demod2On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod2Y]
+label: Demodulator 2 Y
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 2
+section: Trace
+get_cmd: /%s/demods/1/sample
+state_quant: Demod2On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod2R]
+label: Demodulator 2 R
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 2
+section: Trace
+get_cmd: /%s/demods/1/sample
+state_quant: Demod2On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod2phi]
+label: Demodulator 2 Phi
+datatype: VECTOR
+x_unit: s
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 2
+section: Trace
+get_cmd: /%s/demods/1/sample
+state_quant: Demod2On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod3SampleRate]
+label: Demodulator 3 Sample Rate
+datatype: DOUBLE
+unit: Sa/s
+group: Demodulator 3
+section: Trace
+get_cmd: /%s/demods/2/rate
+
+[TraceDemod3X]
+label: Demodulator 3 X
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 3
+section: Trace
+get_cmd: /%s/demods/2/sample
+state_quant: Demod3On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod3Y]
+label: Demodulator 3 Y
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 3
+section: Trace
+get_cmd: /%s/demods/2/sample
+state_quant: Demod3On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod3R]
+label: Demodulator 3 R
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 3
+section: Trace
+get_cmd: /%s/demods/2/sample
+state_quant: Demod3On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod3phi]
+label: Demodulator 3 Phi
+datatype: VECTOR
+x_unit: s
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 3
+section: Trace
+get_cmd: /%s/demods/2/sample
+state_quant: Demod3On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod4SampleRate]
+label: Demodulator 4 Sample Rate
+datatype: DOUBLE
+unit: Sa/s
+group: Demodulator 4
+section: Trace
+get_cmd: /%s/demods/3/rate
+
+[TraceDemod4X]
+label: Demodulator 4 X
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 4
+section: Trace
+get_cmd: /%s/demods/3/sample
+state_quant: Demod4On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod4Y]
+label: Demodulator 4 Y
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 4
+section: Trace
+get_cmd: /%s/demods/3/sample
+state_quant: Demod4On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod4R]
+label: Demodulator 4 R
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 4
+section: Trace
+get_cmd: /%s/demods/3/sample
+state_quant: Demod4On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod4phi]
+label: Demodulator 4 Phi
+datatype: VECTOR
+x_unit: s
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 4
+section: Trace
+get_cmd: /%s/demods/3/sample
+state_quant: Demod4On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod5SampleRate]
+label: Demodulator 5 Sample Rate
+datatype: DOUBLE
+unit: Sa/s
+group: Demodulator 5
+section: Trace
+get_cmd: /%s/demods/4/rate
+
+[TraceDemod5X]
+label: Demodulator 5 X
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 5
+section: Trace
+get_cmd: /%s/demods/4/sample
+state_quant: Demod5On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod5Y]
+label: Demodulator 5 Y
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 5
+section: Trace
+get_cmd: /%s/demods/4/sample
+state_quant: Demod5On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod5R]
+label: Demodulator 5 R
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 5
+section: Trace
+get_cmd: /%s/demods/4/sample
+state_quant: Demod5On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod5phi]
+label: Demodulator 5 Phi
+datatype: VECTOR
+x_unit: s
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 5
+section: Trace
+get_cmd: /%s/demods/4/sample
+state_quant: Demod5On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod6SampleRate]
+label: Demodulator 6 Sample Rate
+datatype: DOUBLE
+unit: Sa/s
+group: Demodulator 6
+section: Trace
+get_cmd: /%s/demods/5/rate
+
+[TraceDemod6X]
+label: Demodulator 6 X
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 6
+section: Trace
+get_cmd: /%s/demods/5/sample
+state_quant: Demod6On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod6Y]
+label: Demodulator 6 Y
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 6
+section: Trace
+get_cmd: /%s/demods/5/sample
+state_quant: Demod6On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod6R]
+label: Demodulator 6 R
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 6
+section: Trace
+get_cmd: /%s/demods/5/sample
+state_quant: Demod6On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod6phi]
+label: Demodulator 6 Phi
+datatype: VECTOR
+x_unit: s
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 6
+section: Trace
+get_cmd: /%s/demods/5/sample
+state_quant: Demod6On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod7SampleRate]
+label: Demodulator 7 Sample Rate
+datatype: DOUBLE
+unit: Sa/s
+group: Demodulator 7
+section: Trace
+get_cmd: /%s/demods/6/rate
+
+[TraceDemod7X]
+label: Demodulator 7 X
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 7
+section: Trace
+get_cmd: /%s/demods/6/sample
+state_quant: Demod7On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod7Y]
+label: Demodulator 7 Y
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 7
+section: Trace
+get_cmd: /%s/demods/6/sample
+state_quant: Demod7On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod7R]
+label: Demodulator 7 R
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 7
+section: Trace
+get_cmd: /%s/demods/6/sample
+state_quant: Demod7On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod7phi]
+label: Demodulator 7 Phi
+datatype: VECTOR
+x_unit: s
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 7
+section: Trace
+get_cmd: /%s/demods/6/sample
+state_quant: Demod7On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[Demod8SampleRate]
+label: Demodulator 8 Sample Rate
+datatype: DOUBLE
+unit: Sa/s
+group: Demodulator 8
+section: Trace
+get_cmd: /%s/demods/7/rate
+
+[TraceDemod8X]
+label: Demodulator 8 X
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 8
+section: Trace
+get_cmd: /%s/demods/7/sample
+state_quant: Demod8On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod8Y]
+label: Demodulator 8 Y
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 8
+section: Trace
+get_cmd: /%s/demods/7/sample
+state_quant: Demod8On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod8R]
+label: Demodulator 8 R
+datatype: VECTOR
+unit: V
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 8
+section: Trace
+get_cmd: /%s/demods/7/sample
+state_quant: Demod8On
+state_value_1: True
+show_in_measurement_dlg: True
+
+[TraceDemod8phi]
+label: Demodulator 8 Phi
+datatype: VECTOR
+x_unit: s
+x_name: Time
+x_unit: s
+permission: READ
+group: Demodulator 8
+section: Trace
+get_cmd: /%s/demods/7/sample
+state_quant: Demod8On
+state_value_1: True
+show_in_measurement_dlg: True
+
+
+#######################################################################
+### Modulators ########################################################
+#######################################################################
+
+[Mod1On]
+label: Modulator 1 Enable
+datatype: BOOLEAN
+group: Modulator 1
+section: Modulators
+get_cmd: /%s/mods/0/enable
+option_value_1: MOD
+
+[Mod1Mode]
+label: Modulator 1 Mode
+datatype: COMBO
+combo_def_1: AM
+combo_def_2: FM
+combo_def_3: Manual
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+group: Modulator 1
+section: Modulators
+get_cmd: /%s/mods/0/mode
+option_value_1: MOD
+
+[Mod1SB1Mode]
+label: Modulator 1 Sideband 1 Mode
+datatype: COMBO
+combo_def_1: Off
+combo_def_2: C+M
+combo_def_3: C-M
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+group: Modulator 1
+section: Modulators
+get_cmd: /%s/mods/0/sidebands/0/mode
+option_value_1: MOD
+state_quant: Mod1Mode
+state_value_1: Manual
+
+[Mod1SB2Mode]
+label: Modulator 1 Sideband 2 Mode
+datatype: COMBO
+combo_def_1: Off
+combo_def_2: C+M
+combo_def_3: C-M
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+group: Modulator 1
+section: Modulators
+get_cmd: /%s/mods/0/sidebands/1/mode
+option_value_1: MOD
+state_quant: Mod1Mode
+state_value_1: Manual
+
+[Mod1Osc]
+label: Modulator 1 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Modulator 1
+section: Modulators
+get_cmd: /%s/mods/0/carrier/oscselect
+option_value_1: MOD
+
+[Mod1SB1Osc]
+label: Modulator 1 Sideband 1 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Modulator 1
+section: Modulators
+get_cmd: /%s/mods/0/sidebands/0/oscselect
+option_value_1: MOD
+
+[Mod1SB2Osc]
+label: Modulator 1 Sideband 2 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Modulator 1
+section: Modulators
+get_cmd: /%s/mods/0/sidebands/1/oscselect
+option_value_1: MOD
+state_quant: Mod1Mode
+state_value_1: Manual
+
+[Mod1Phase]
+label: Modulator 1 Phase
+datatype: DOUBLE
+unit: deg
+group: Modulator 1
+section: Modulator
+get_cmd: /%s/mods/0/carrier/phaseshift
+option_value_1: MOD
+
+[Mod1SB1Phase]
+label: Modulator 1 Sideband 1 Phase
+datatype: DOUBLE
+unit: deg
+group: Modulator 1
+section: Modulator
+get_cmd: /%s/mods/0/sidebands/0/phaseshift
+option_value_1: MOD
+
+[Mod1SB2Phase]
+label: Modulator 1 Sideband 2 Phase
+datatype: DOUBLE
+unit: deg
+group: Modulator 1
+section: Modulator
+get_cmd: /%s/mods/0/sidebands/1/phaseshift
+option_value_1: MOD
+state_quant: Mod1Mode
+state_value_1: Manual
+
+[Mod1TC]
+label: Modulator 1 Time Constant
+datatype: DOUBLE
+unit: s
+group: Modulator 1
+section: Modulator
+get_cmd: /%s/mods/0/carrier/timeconstant
+option_value_1: MOD
+
+[Mod1SB1TC]
+label: Modulator 1 Sideband 1 Time Constant
+datatype: DOUBLE
+unit: s
+group: Modulator 1
+section: Modulator
+get_cmd: /%s/mods/0/sidebands/0/timeconstant
+option_value_1: MOD
+
+[Mod1SB2TC]
+label: Modulator 1 Sideband 2 Time Constant
+datatype: DOUBLE
+unit: s
+group: Modulator 1
+section: Modulator
+get_cmd: /%s/mods/0/sidebands/1/timeconstant
+option_value_1: MOD
+state_quant: Mod1Mode
+state_value_1: Manual
+
+[Mod1OutAmp]
+label: Modulator 1 Output Amp
+datatype: DOUBLE
+unit: V
+group: Modulator 1
+section: Modulator
+get_cmd: /%s/mods/0/carrier/amplitude
+option_value_1: MOD
+
+[Mod1SB1OutAmp]
+label: Modulator 1 Sideband 1 Output Amp
+datatype: DOUBLE
+unit: V
+group: Modulator 1
+section: Modulator
+get_cmd: /%s/mods/0/sidebands/0/amplitude
+option_value_1: MOD
+
+[Mod1SB2OutAmp]
+label: Modulator 1 Sideband 2 Output Amp
+datatype: DOUBLE
+unit: V
+group: Modulator 1
+section: Modulator
+get_cmd: /%s/mods/0/sidebands/1/amplitude
+option_value_1: MOD
+state_quant: Mod1Mode
+state_value_1: Manual
+
+[Mod2On]
+label: Modulator 2 Enable
+datatype: BOOLEAN
+group: Modulator 2
+section: Modulators
+get_cmd: /%s/mods/1/enable
+option_value_1: MOD
+
+[Mod2Mode]
+label: Modulator 2 Mode
+datatype: COMBO
+combo_def_1: AM
+combo_def_2: FM
+combo_def_3: Manual
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+group: Modulator 2
+section: Modulators
+get_cmd: /%s/mods/1/mode
+option_value_1: MOD
+
+[Mod2SB1Mode]
+label: Modulator 2 Sideband 1 Mode
+datatype: COMBO
+combo_def_1: Off
+combo_def_2: C+M
+combo_def_3: C-M
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+group: Modulator 2
+section: Modulators
+get_cmd: /%s/mods/1/sidebands/0/mode
+option_value_1: MOD
+state_quant: Mod2Mode
+state_value_1: Manual
+
+[Mod2SB2Mode]
+label: Modulator 2 Sideband 2 Mode
+datatype: COMBO
+combo_def_1: Off
+combo_def_2: C+M
+combo_def_3: C-M
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+group: Modulator 2
+section: Modulators
+get_cmd: /%s/mods/1/sidebands/1/mode
+option_value_1: MOD
+state_quant: Mod2Mode
+state_value_1: Manual
+
+[Mod2Osc]
+label: Modulator 2 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Modulator 2
+section: Modulators
+get_cmd: /%s/mods/1/carrier/oscselect
+option_value_1: MOD
+
+[Mod2SB1Osc]
+label: Modulator 2 Sideband 1 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Modulator 2
+section: Modulators
+get_cmd: /%s/mods/1/sidebands/0/oscselect
+option_value_1: MOD
+
+[Mod2SB2Osc]
+label: Modulator 2 Sideband 2 Oscillator
+datatype: COMBO
+combo_def_1: Oscillator 1
+combo_def_2: Oscillator 2
+combo_def_3: Oscillator 3
+combo_def_4: Oscillator 4
+combo_def_5: Oscillator 5
+combo_def_6: Oscillator 6
+combo_def_7: Oscillator 7
+combo_def_8: Oscillator 8
+cmd_def_1: 0
+cmd_def_2: 1
+cmd_def_3: 2
+cmd_def_4: 3
+cmd_def_5: 4
+cmd_def_6: 5
+cmd_def_7: 6
+cmd_def_8: 7
+group: Modulator 2
+section: Modulators
+get_cmd: /%s/mods/1/sidebands/1/oscselect
+option_value_1: MOD
+state_quant: Mod2Mode
+state_value_1: Manual
+
+[Mod2Phase]
+label: Modulator 2 Phase
+datatype: DOUBLE
+unit: deg
+group: Modulator 2
+section: Modulator
+get_cmd: /%s/mods/1/carrier/phaseshift
+option_value_1: MOD
+
+[Mod2SB1Phase]
+label: Modulator 2 Sideband 1 Phase
+datatype: DOUBLE
+unit: deg
+group: Modulator 2
+section: Modulator
+get_cmd: /%s/mods/1/sidebands/0/phaseshift
+option_value_1: MOD
+
+[Mod2SB2Phase]
+label: Modulator 2 Sideband 2 Phase
+datatype: DOUBLE
+unit: deg
+group: Modulator 2
+section: Modulator
+get_cmd: /%s/mods/1/sidebands/1/phaseshift
+option_value_1: MOD
+state_quant: Mod2Mode
+state_value_1: Manual
+
+[Mod2TC]
+label: Modulator 2 Time Constant
+datatype: DOUBLE
+unit: s
+group: Modulator 2
+section: Modulator
+get_cmd: /%s/mods/1/carrier/timeconstant
+option_value_1: MOD
+
+[Mod2SB1TC]
+label: Modulator 2 Sideband 1 Time Constant
+datatype: DOUBLE
+unit: s
+group: Modulator 2
+section: Modulator
+get_cmd: /%s/mods/1/sidebands/0/timeconstant
+option_value_1: MOD
+
+[Mod2SB2TC]
+label: Modulator 2 Sideband 2 Time Constant
+datatype: DOUBLE
+unit: s
+group: Modulator 2
+section: Modulator
+get_cmd: /%s/mods/1/sidebands/1/timeconstant
+option_value_1: MOD
+state_quant: Mod2Mode
+state_value_1: Manual
+
+[Mod2OutAmp]
+label: Modulator 2 Output Amp
+datatype: DOUBLE
+unit: V
+group: Modulator 2
+section: Modulator
+get_cmd: /%s/mods/1/carrier/amplitude
+option_value_1: MOD
+
+[Mod2SB1OutAmp]
+label: Modulator 2 Sideband 1 Output Amp
+datatype: DOUBLE
+unit: V
+group: Modulator 2
+section: Modulator
+get_cmd: /%s/mods/1/sidebands/0/amplitude
+option_value_1: MOD
+
+[Mod2SB2OutAmp]
+label: Modulator 2 Sideband 2 Output Amp
+datatype: DOUBLE
+unit: V
+group: Modulator 2
+section: Modulator
+get_cmd: /%s/mods/1/sidebands/1/amplitude
+option_value_1: MOD
+state_quant: Mod2Mode
+state_value_1: Manual

--- a/Zurich Instruments UHF/Zurich Instruments UHF.py
+++ b/Zurich Instruments UHF/Zurich Instruments UHF.py
@@ -1,0 +1,200 @@
+import InstrumentDriver
+import numpy as np
+import os, sys, inspect, re, math
+
+#Some stuff to import ziPython from a relative path independent from system wide installations
+cmd_folder = os.path.realpath(os.path.abspath(os.path.split(inspect.getfile(inspect.currentframe()))[0]))
+if cmd_folder not in sys.path:
+    sys.path.insert(0, cmd_folder)
+
+import zhinst.utils as zi
+
+class Driver(InstrumentDriver.InstrumentWorker):
+    """ This class wraps the ziPython API"""
+    
+
+    def performOpen(self, options={}):
+        """Perform the operation of opening the instrument connection"""
+        
+        try:
+            self.ziConnection = zi.autoConnect(8004, 4)
+        except:
+            raise InstrumentDriver.CommunicationError("Could not connect to Zurich Instruments Data Server. Is it running?")
+            return
+
+        if self.comCfg.address == "":
+            self.device = zi.autoDetect(self.ziConnection)
+            self.log("Autodetected Zurich Instruments device \"" + self.device + "\". Use the address field to set a specific device.")
+        else:
+            self.device = self.comCfg.address
+        
+        try:
+            devtype = self.ziConnection.getByte('/%s/features/devtype' % self.device)
+        except:
+            raise InstrumentDriver.CommunicationError("Device " + self.device + " not found.")
+            return
+            
+        if re.match('UHF', devtype):
+            self.log("Zurich Instruments device \"" + self.device + "\" has been accepted by the driver.")
+        else:
+            self.log("Zurich Instruments device \"" + self.device + "\" has been rejected by the driver.", 50)
+            raise InstrumentDriver.CommunicationError("Device " + self.device + " is not an UHF lock-in")
+            return
+        
+        #Check Options
+        devoptions = self.ziConnection.getByte('/%s/features/options' % self.device)
+        detectedOptions = []
+        if re.search('MOD', devoptions):
+            detectedOptions.append("MOD")
+        self.instrCfg.setInstalledOptions(detectedOptions)
+
+    def performClose(self, bError=False, options={}):
+        """Perform the close instrument connection operation"""
+        pass
+
+
+    def performSetValue(self, quant, value, sweepRate=0.0, options={}):
+        """Perform the Set Value instrument operation. This function should
+        return the actual value set by the instrument"""
+        #Simple booleans
+        if quant.name in ['SigOut1On', 'SigOut2On'] + \
+                        ['SigIn1AC', 'SigIn2AC'] + \
+                        ['Mod1On', 'Mod2On'] + \
+                        ['Out'+str(x+1)+'SigOut' + str(y+1) + 'On' for x in range(8) for y in range(2)] + \
+                        ['Demod'+str(x+1)+'On' for x in range(8)]:
+            self.ziConnection.setInt(quant.get_cmd % self.device, 1 if value else 0)
+        #Simple floating points
+        elif quant.name in ['SigIn1Range', 'SigIn2Range'] + \
+                        ['Oscillator'+str(x+1)+'Frequency' for x in range(8)] + \
+                        ['Out'+str(x+1)+'SigOut' + str(y+1) + 'Amp' for x in range(8) for y in range(2)] + \
+                        ['Demod'+str(x+1)+'RefPhase' for x in range(8)] + \
+                        ['Demod'+str(x+1)+'TC' for x in range(8)] + \
+                        ['Demod'+str(x+1)+'SampleRate' for x in range(8)] + \
+                        ['Mod1Phase', 'Mod2Phase'] + \
+                        ['Mod1SB1Phase', 'Mod2SB1Phase'] + \
+                        ['Mod1SB2Phase', 'Mod2SB2Phase'] + \
+                        ['Mod1TC', 'Mod2TC'] + \
+                        ['Mod1SB1TC', 'Mod2SB1TC'] + \
+                        ['Mod1SB2TC', 'Mod2SB2TC'] + \
+                        ['Mod1OutAmp', 'Mod2OutAmp'] + \
+                        ['Mod1SB1OutAmp', 'Mod2SB1OutAmp'] + \
+                        ['Mod1SB2OutAmp', 'Mod2SB2OutAmp']:
+            self.ziConnection.setDouble(quant.get_cmd % self.device, value)
+        #Combos (Oscillator-selector for demodulators and Modulator mode)
+        elif quant.name in ['Demod'+str(x+1)+'Osc' for x in range(8)] + \
+                            ['Mod1Mode', 'Mod2Mode'] + \
+                            ['Mod1SB1Mode', 'Mod2SB1Mode'] + \
+                            ['Mod1SB2Mode', 'Mod2SB2Mode'] + \
+                            ['Mod1Osc', 'Mod2Osc'] + \
+                            ['Mod1SB1Osc', 'Mod2SB1Osc'] + \
+                            ['Mod1SB2Osc', 'Mod2SB2Osc']:
+            self.ziConnection.setInt(quant.get_cmd % self.device, value)
+        return value
+
+
+    def performGetValue(self, quant, options={}):
+        if self.isFirstCall(options):
+            self.resultBuffer = {}
+            self.traceBuffer = {}
+        """Perform the Get Value instrument operation"""
+        # proceed depending on quantity
+        #Simple booleans
+        if quant.name in ['SigOut1On', 'SigOut2On'] + \
+                        ['SigIn1AC', 'SigIn2AC'] + \
+                        ['Mod1On', 'Mod2On'] + \
+                        ['Out'+str(x+1)+'SigOut' + str(y+1) + 'On' for x in range(8) for y in range(2)] + \
+                        ['Demod'+str(x+1)+'On' for x in range(8)]:
+            return (self.ziConnection.getInt(quant.get_cmd % self.device) > 0)
+        #Simple floating points
+        elif quant.name in ['SigIn1Range', 'SigIn2Range'] + \
+                        ['Oscillator'+str(x+1)+'Frequency' for x in range(8)] + \
+                        ['Out'+str(x+1)+'SigOut' + str(y+1) + 'Amp' for x in range(8) for y in range(2)] + \
+                        ['Demod'+str(x+1)+'RefPhase' for x in range(8)] + \
+                        ['Demod'+str(x+1)+'TC' for x in range(8)] + \
+                        ['Demod'+str(x+1)+'SampleRate' for x in range(8)] + \
+                        ['Mod1Phase', 'Mod2Phase'] + \
+                        ['Mod1SB1Phase', 'Mod2SB1Phase'] + \
+                        ['Mod1SB2Phase', 'Mod2SB2Phase'] + \
+                        ['Mod1TC', 'Mod2TC'] + \
+                        ['Mod1SB1TC', 'Mod2SB1TC'] + \
+                        ['Mod1SB2TC', 'Mod2SB2TC'] + \
+                        ['Mod1OutAmp', 'Mod2OutAmp'] + \
+                        ['Mod1SB1OutAmp', 'Mod2SB1OutAmp'] + \
+                        ['Mod1SB2OutAmp', 'Mod2SB2OutAmp']:
+            return self.ziConnection.getDouble(quant.get_cmd % self.device)
+        #Read-out channels of demodulator
+        elif quant.name in ['Demod'+str(x+1)+'R' for x in range(8)] + \
+                        ['Demod'+str(x+1)+'phi' for x in range(8)] + \
+                        ['Demod'+str(x+1)+'X' for x in range(8)] + \
+                        ['Demod'+str(x+1)+'Y' for x in range(8)]:
+            if quant.get_cmd in self.resultBuffer.keys():
+                data = self.resultBuffer[quant.get_cmd]
+            else:
+                data = self.ziConnection.getSample(quant.get_cmd % self.device)
+                self.resultBuffer[quant.get_cmd] = data
+            channel = quant.name[6:]
+            if channel == "X":
+                return data["x"][0]
+            elif channel == "Y":
+                return data["y"][0]
+            elif channel == "R":
+                return math.sqrt(data["x"][0]**2 + data["y"][0]**2)
+            elif channel == "phi":
+                return math.degrees(math.atan2(data["y"][0], data["x"][0]))
+            return float('nan')
+        #Trace channels of demodulator
+        elif quant.name in ['TraceDemod'+str(x+1)+'R' for x in range(8)] + \
+                        ['TraceDemod'+str(x+1)+'phi' for x in range(8)] + \
+                        ['TraceDemod'+str(x+1)+'X' for x in range(8)] + \
+                        ['TraceDemod'+str(x+1)+'Y' for x in range(8)]:
+            if (quant.get_cmd % self.device) in self.traceBuffer.keys():
+                data = self.traceBuffer[quant.get_cmd % self.device]
+            else:
+                self.ziConnection.sync()
+                subChannels = []
+                for i in range(8):
+                    if self.getValue('Demod'+str(i+1)+"On"):
+                        subChannels.append("/%s/demods/%d/sample" % (self.device, i))
+                self.ziConnection.flush()
+                self.ziConnection.subscribe(subChannels)
+                self.traceBuffer = self.ziConnection.poll(self.getValue("TraceLength"), 500, 1, True)
+                self.ziConnection.unsubscribe('*')
+                self.clockbase = float(self.ziConnection.getInt('/%s/clockbase' % self.device))
+                data = self.traceBuffer[quant.get_cmd % self.device]
+            dt = (data['timestamp'][-1] - data['timestamp'][0])/self.clockbase/(len(data['timestamp'])+1)
+            channel = quant.name[11:]
+            nPoints = self.getValue("TraceLength")*self.getValue("Demod"+quant.name[10]+"SampleRate")
+            if channel == "X":
+                signal = quant.getTraceDict(data["x"][:nPoints], t0=0.0, dt=dt)
+                self.log("Return X")
+                self.log(signal)
+                return signal
+            elif channel == "Y":
+                signal = quant.getTraceDict(data["y"][:nPoints], t0=0.0, dt=dt)
+                self.log("Return Y")
+                self.log(signal)
+                return signal
+            elif channel == "R":
+                signal = quant.getTraceDict(np.sqrt(np.array(data["x"][:nPoints])**2 + np.array(data["y"][:nPoints])**2), t0=0.0, dt=dt)
+                self.log("Return R")
+                self.log(signal)
+                return signal
+            elif channel == "phi":
+                signal = quant.getTraceDict(np.degrees(np.arctan2(np.array(data["y"][:nPoints]), np.array(data["x"][:nPoints]))), t0=0.0, dt=dt)
+                self.log("Return phi")
+                self.log(signal)
+                return signal
+            return quant.getTraceDict([])
+        #Combos (Oscillator-selector for demodulators and Modulator mode)
+        elif quant.name in ['Demod'+str(x+1)+'Osc' for x in range(8)] + \
+                            ['Mod1Mode', 'Mod2Mode'] + \
+                            ['Mod1SB1Mode', 'Mod2SB1Mode'] + \
+                            ['Mod1SB2Mode', 'Mod2SB2Mode'] + \
+                            ['Mod1Osc', 'Mod2Osc'] + \
+                            ['Mod1SB1Osc', 'Mod2SB1Osc'] + \
+                            ['Mod1SB2Osc', 'Mod2SB2Osc']:
+            return quant.getValueFromCmdString(self.ziConnection.getInt(quant.get_cmd % self.device))
+        # for other quantities, just return current value of control
+        return quant.getValue()
+
+

--- a/Zurich Instruments UHF/readme.md
+++ b/Zurich Instruments UHF/readme.md
@@ -1,0 +1,3 @@
+#Zurich Instruments UHF
+
+This driver encapsulates most features of the Zurich Instruments UHF lock-in amplifier. However, communication is done through ziPython and the LabOne server, which you will have to obtain both from Zurich Instruments. While the LabOne server needs to be running during measurement, the ziPython libs need to be copied to the driver path. Just install ziPython (you do not need an actual local Python installation) and copy the zhinst folder from *C:\PythonX\Lib\site-packages\* to the driver folder (next to *Zurich Instruments UHF.py*).


### PR DESCRIPTION
This driver uses ziPython, which may not be redistributed. Installation
instructions are provided in the readme.md.