### PR TITLE
Triton optimizations and fix for Labber 1.0.6

### DIFF
--- a/Triton/Triton.ini
+++ b/Triton/Triton.ini
@@ -6,7 +6,7 @@
 name: Triton 200 dilution fridge
 
 # The version string should be updated whenever changes are made to this config file
-version: 1.2
+version: 1.2.1
 
 # Name of folder containing the code defining a custom driver. Do not define this item
 # or leave it blank for any standard driver based on the built-in VISA interface.

--- a/Triton/Triton.py
+++ b/Triton/Triton.py
@@ -87,8 +87,6 @@ class Driver(VISA_Driver):
         elif quant.name in ('Bx', 'By', 'Bz', 'Br', 'Brho', 'Bphi', 'Btheta'):
             coordFunc = self.instrCfg.getQuantity('CoordSys')
             if not self.Bresult:
-                self.performSetValue(coordFunc, coordFunc.getValue())
-                self.performGetValue(coordFunc)
                 vectValue = self.askAndLog(quant.get_cmd).strip()
                 self.Bresult = vectValue.rsplit(':',1)[1][1:-1].translate(None,string.letters).split()
             #Vector results depend on the coordinate system

--- a/Triton/Triton.py
+++ b/Triton/Triton.py
@@ -6,7 +6,6 @@ import visa
 from InstrumentConfig import InstrumentQuantity
 import numpy as np
 import string
-import Tkinter as Tk
 
 __version__ = "0.0.1"
 


### PR DESCRIPTION
Removed an unnessecary import, which did no longer work in Labber 1.0.6 and reduced the communication load when reading the field.