### PR TITLE
Lakeshore 33x

### DIFF
--- a/Lakeshore 33x/Lakeshore 33x.ini
+++ b/Lakeshore 33x/Lakeshore 33x.ini
@@ -10,7 +10,7 @@ version: 1.0
 
 # Name of folder containing the code defining a custom driver. Do not define this item
 # or leave it blank for any standard driver based on the built-in VISA interface.
-driver_path:
+driver_path: Lakeshore 33x
 
 
 
@@ -112,14 +112,14 @@ datatype: DOUBLE
 permission: READ
 get_cmd: KRDG? C
 unit: K
-model_value_1: MODEL336
+model_value_1: Lakeshore 336
 
 [Temperature D]
 datatype: DOUBLE
 permission: READ
 get_cmd: KRDG? D
 unit: K
-model_value_1: MODEL336
+model_value_1: Lakeshore 336
 
 [Raw A]
 datatype: DOUBLE
@@ -138,35 +138,35 @@ datatype: DOUBLE
 permission: READ
 get_cmd: SRDG? C
 unit: Ohm
-model_value_1: MODEL336
+model_value_1: Lakeshore 336
 
 [Raw D]
 datatype: DOUBLE
 permission: READ
 get_cmd: SRDG? D
 unit: Ohm
-model_value_1: MODEL336
+model_value_1: Lakeshore 336
 
 [Heater]
 datatype: DOUBLE
 permission: READ
 get_cmd: HTR?
 unit: %
-model_value_1: MODEL332
+model_value_1: Lakeshore 332
 
 [Heater 1]
 datatype: DOUBLE
 permission: READ
 get_cmd: HTR? 1
 unit: %
-model_value_1: MODEL336
+model_value_1: Lakeshore 336
 
 [Heater 2]
 datatype: DOUBLE
 permission: READ
 get_cmd: HTR? 2
 unit: %
-model_value_1: MODEL336
+model_value_1: Lakeshore 336
 
 [Setpoint 1]
 datatype: DOUBLE
@@ -185,11 +185,11 @@ datatype: DOUBLE
 get_cmd: SETP? 3
 set_cmd: SETP: 3,
 unit: K
-model_value_1: MODEL336
+model_value_1: Lakeshore 336
 
 [Setpoint 4]
 datatype: DOUBLE
 get_cmd: SETP? 4
 set_cmd: SETP: 4,
 unit: K
-model_value_1: MODEL336
+model_value_1: Lakeshore 336

--- a/Lakeshore 33x/Lakeshore 33x.py
+++ b/Lakeshore 33x/Lakeshore 33x.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+
+from VISA_Driver import VISA_Driver
+
+__version__ = "0.0.1"
+
+class Error(Exception):
+    pass
+
+class Driver(VISA_Driver):
+    """ This class implements the Lakeshore 33x driver"""
+        
+    def performSetValue(self, quant, value, sweepRate=0.0, options={}):
+        """Perform the set value operation"""
+        # The default precision of labber is too high...
+        self.writeAndLog(quant.set_cmd + str(value))
+        return value
+        
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
This bugfix corrects two problems:
- Wrong values for setpoints as the device cannot cope with the excessive default precision for float values in Labber
- Channels that should show for specific devices did not show up at all