### PR TITLE
Driver for Keysight S-series Oscilloscope

### DIFF
--- a/Keysight_S-Series_Oscilloscope/Keysight_S-Series_Oscilloscope.ini
+++ b/Keysight_S-Series_Oscilloscope/Keysight_S-Series_Oscilloscope.ini
@@ -1,0 +1,502 @@
+# Instrument driver configuration file.
+
+[General settings]
+
+# The name is shown in all the configuration windows
+name: Keysight S-Series Oscilloscope
+
+# The version string should be updated whenever changes are made to this config file
+version: 1.0
+
+# Name of folder containing the code defining a custom driver. Do not define this item
+# or leave it blank for any standard driver based on the built-in VISA interface.
+driver_path: Keysight_S-Series_Oscilloscope
+
+# General VISA settings for the instrument.
+[VISA settings]
+
+# Enable or disable communication over the VISA protocol (True or False)
+# If False, the driver will not perform any operations (unless there is a custom driver).
+use_visa = True
+
+# Reset the interface (not the instrument) at startup (True or False).  Default is False
+reset: True
+
+# Time (in seconds) before the timing out while waiting for an instrument response. Default is 5
+timeout: 10
+
+# Query instrument errors (True or False).  If True, every command sent to the device will
+# be followed by an error query.  This is useful when testing new setups, but may degrade
+# performance by slowing down the instrument communication. 
+query_instr_errors: False 
+
+# Bit mask for checking status byte errors (default is 255, include all errors)
+# The bits signal the following errors:
+# 0: Operation
+# 1: Request control
+# 2: Query error
+# 3: Device error
+# 4: Execution error
+# 5: Command error
+# 6: User request
+# 7: Power on
+error_bit_mask: 255
+
+# SCPI string to be used when querying for instrument error messages
+error_cmd: :SYST:ERR?
+
+# Initialization commands are sent to the instrument when starting the driver
+# *RST will reset the device, *CLS clears the interface, :BAND:VID:AUTO 1
+init: :INIT:CONT ON;:FORM:BORD NORM
+
+# Boolean string values (used for sending True/False to instrument), default is 1 and 0
+#str_true: ON
+#str_false: OFF
+
+# Final commands sent to the instrument when closing the driver
+final: 
+
+
+[Model and options]
+# The option section allow instruments with different options to use the same driver
+
+# List of models supported by this driver
+# model_str_1: N90xx
+
+# Check instrument model id at startup (True or False). Default is False
+# check_model: True
+
+# If check_model is set to True, define command for getting the model (default is *IDN?)
+#model_cmd: *IDN?
+
+# Valid model strings returned by the instrument. Default value = model_str
+model_id_1: KEYSIGHT TECHNOLOGIES,DSOS
+
+# Define quantities in sections. This list is a selection of allowed keywords,
+# see the manual for a full list of options
+#   datatype:      The datatype should be one of DOUBLE, BOOLEAN, COMBO,
+#                  STRING, COMPLEX, VECTOR, VECTOR_COMPLEX, PATH or BUTTON.
+#   unit:          Quantity unit
+#   set_cmd:       Command used to send data to the instrument. Put <*> where the value should appear.
+#   get_cmd:       Command used to get the data from the instrument. Default is set_cmd?
+#   def_value:     Default value
+#   low_lim:       Lowest allowable value.  Defaults to -INF
+#   high_lim:      Highest allowable values.  Defaults to +INF
+#   combo_def_1:   First option in a pull-down combo box. Only used when datatype=COMBO
+#   combo_def_2:   Second option in a pull-down combo box. Only used when datatype=COMBO
+#   ...
+#   combo_def_n:   nth option in a pull-down combo box. Only used when datatype=COMBO
+#   state_quant:   Quantity that determines this control's visibility
+#   state_value_1: Value of "state_quant" for which the control is visible
+#   state_value_2: Value of "state_quant" for which the control is visible
+#   ...
+#   state_value_n: Value of "state_quant" for which the control is visible
+#   permission:    Sets read/writability, options are BOTH, READ, WRITE or NONE. Default is BOTH 
+#   group:         Name of the group where the control belongs.
+#   section:       Name of the section where the control belongs.
+
+#define Acquisition mode.  There are a bunch of dependency issues if both are selected.
+
+#define all settings common to both modes here.
+
+[Time range]
+unit: s
+datatype: DOUBLE
+def_value: 1e-6
+low_lim: 50e-12
+high_lim: 200
+set_cmd: :TIM:RANG
+get_cmd: :TIM:RANG?
+section: Settings
+group: Timebase
+show_in_measurement_dlg: True
+
+[Sample points]
+datatype: DOUBLE
+def_value: 8000
+set_cmd: :ACQ:POIN:ANAL
+get_cmd: :ACQ:POIN:ANAL?
+section: Settings
+group: Timebase
+# state_quant: Precedence: points/rate?
+# state_value_1: Points
+
+[Sample rate]
+datatype: DOUBLE
+def_value: 20E9
+high_lim: 20E9
+set_cmd: :ACQ:SRAT:ANAL
+get_cmd: :ACQ:SRAT:ANAL?
+section: Settings
+group: Timebase
+# state_quant: Precedence: points/rate?
+# state_value_1: Rate
+
+[Time position]
+unit: s
+datatype: DOUBLE
+def_value: 0
+set_cmd: :TIM:POS
+get_cmd: :TIM:POS?
+section: Settings
+group: Timebase
+show_in_measurement_dlg: True
+
+[10 MHz reference clock]
+datatype: COMBO
+def_value: OFF
+combo_def_1: ON
+combo_def_2: OFF
+cmd_def_1: 0
+cmd_def_2: 1
+set_cmd: :TIM:REFC
+get_cmd: :TIM:REFC?
+section: Settings
+group: Timebase
+
+[Location of zero]
+datatype: COMBO
+def_value: LEFT
+combo_def_1: LEFT
+combo_def_2: CENTER
+combo_def_3: RIGHT
+cmd_def_1: LEFT
+cmd_def_2: CENT
+cmd_def_3: RIGH
+set_cmd: :TIM:REF
+get_cmd: :TIM:REF?
+section: Settings
+group: Timebase
+
+# this quantity needs to be handled in the .py driver
+# because the channel quantity needs to be specified.
+# :TRIG:MODE EDGE should be implemented always
+
+[Trigger source]
+datatype: COMBO
+def_value: Channel 2
+combo_def_1: Channel 1
+combo_def_2: Channel 2
+combo_def_3: Channel 3
+combo_def_4: Channel 4
+combo_def_5: AUX
+combo_def_6: LINE
+cmd_def_1: CHAN1
+cmd_def_2: CHAN2
+cmd_def_3: CHAN3
+cmd_def_4: CHAN4
+cmd_def_5: AUX
+cmd_def_6: LINE
+set_cmd: :TRIG:EDGE:SOUR
+get_cmd: :TRIG:EDGE:SOUR?
+section: Settings
+group: Trigger
+
+[Trigger coupling]
+datatype: COMBO
+def_value: DC
+combo_def_1: DC
+combo_def_2: AC
+cmd_def_1: DC
+cmd_def_2: AC
+set_cmd: :TRIG:EDGE:COUP
+get_cmd: :TRIG:EDGE:COUP?
+section: Settings
+group: Trigger
+
+[Trigger slope]
+datatype: COMBO
+def_value: Positive
+combo_def_1: Positive
+combo_def_2: Negative
+combo_def_3: Either
+cmd_def_1: POS
+cmd_def_2: NEG
+cmd_def_3: EITH
+set_cmd: :TRIG:EDGE:SLOP
+get_cmd: :TRIG:EDGE:SLOP?
+section: Settings
+group: Trigger
+
+[Trigger level]
+datatype: DOUBLE
+def_value: 0.5
+section: Settings
+group: Trigger
+
+[Averaging]
+datatype: BOOLEAN
+def_value: 0
+set_cmd: :ACQ:AVER
+get_cmd: :ACQ:AVER?
+section: Settings
+group: Acquisition
+
+[Number of averages]
+datatype: DOUBLE
+def_value: 1
+low_lim: 2
+high_lim: 65534
+set_cmd: :ACQ:AVER:COUN
+get_cmd: :ACQ:AVER:COUN?
+section: Settings
+group: Acquisition
+state_quant: Averaging
+state_value_1: 1
+
+[Bandwidth]
+datatype: DOUBLE
+def_value: 8e9
+high_lim: 8e9
+low_lim: 500e6
+set_cmd: ACQ:BAND
+get_cmd: ACQ:BAND?
+section: Settings
+
+# Channel 1 - Parameters
+
+[Ch1 - Enabled]
+datatype: BOOLEAN
+def_value: 1
+set_cmd: :CHAN1:DISP
+get_cmd: :CHAN1:DISP?
+section: Channels
+group: Channel 1
+
+[Ch1 - Range]
+datatype: DOUBLE
+def_value: 1
+set_cmd: :CHAN1:RANG
+get_cmd: :CHAN1:RANG?
+section: Channels
+group: Channel 1
+
+[Ch1 - Offset]
+datatype: DOUBLE
+def_value: 0
+set_cmd: :CHAN1:OFFS
+get_cmd: :CHAN1:OFFS?
+section: Channels
+group: Channel 1
+
+[Ch1 - Coupling]
+datatype: COMBO
+def_value: DC - 50 Ohm
+combo_def_1: DC - 50 Ohm
+combo_def_2: DC - 1 MOhm
+combo_def_3: AC - 1 MOhm
+cmd_def_1: DC50
+cmd_def_2: DC
+cmd_def_3: AC
+set_cmd: :CHAN1:INP
+get_cmd: :CHAN1:INP?
+section: Channels
+group: Channel 1
+
+[Ch1 - Bandwidth]
+datatype: COMBO
+def_value: OFF
+combo_def_1: OFF
+combo_def_2: 20 MHz
+combo_def_3: 200 MHz
+cmd_def_1: 0
+cmd_def_2: 20e6
+cmd_def_3: 200e6
+section: Channels
+group: Channel 1
+
+# Channel 2 - Parameters
+
+[Ch2 - Enabled]
+datatype: BOOLEAN
+def_value: 1
+set_cmd: :CHAN2:DISP
+get_cmd: :CHAN2:DISP?
+section: Channels
+group: Channel 2
+
+[Ch2 - Range]
+datatype: DOUBLE
+def_value: 1
+set_cmd: :CHAN2:RANG
+get_cmd: :CHAN2:RANG?
+section: Channels
+group: Channel 2
+
+[Ch2 - Offset]
+datatype: DOUBLE
+def_value: 0
+set_cmd: :CHAN2:OFFS
+get_cmd: :CHAN2:OFFS?
+section: Channels
+group: Channel 2
+
+[Ch2 - Coupling]
+datatype: COMBO
+def_value: DC - 50 Ohm
+combo_def_1: DC - 50 Ohm
+combo_def_2: DC - 1 MOhm
+combo_def_3: AC - 1 MOhm
+cmd_def_1: DC50
+cmd_def_2: DC
+cmd_def_3: AC
+set_cmd: :CHAN2:INP
+get_cmd: :CHAN2:INP?
+section: Channels
+group: Channel 2
+
+[Ch2 - Bandwidth]
+datatype: COMBO
+def_value: OFF
+combo_def_1: OFF
+combo_def_2: 20 MHz
+combo_def_3: 200 MHz
+cmd_def_1: 0
+cmd_def_2: 20e6
+cmd_def_3: 200e6
+section: Channels
+group: Channel 2
+
+# Channel 3 - Parameters
+
+[Ch3 - Enabled]
+datatype: BOOLEAN
+def_value: 0
+set_cmd: :CHAN3:DISP
+get_cmd: :CHAN3:DISP?
+section: Channels
+group: Channel 3
+
+[Ch3 - Range]
+datatype: DOUBLE
+def_value: 1
+set_cmd: :CHAN3:RANG
+get_cmd: :CHAN3:RANG?
+section: Channels
+group: Channel 3
+
+[Ch3 - Offset]
+datatype: DOUBLE
+def_value: 0
+set_cmd: :CHAN3:OFFS
+get_cmd: :CHAN3:OFFS?
+section: Channels
+group: Channel 3
+
+[Ch3 - Coupling]
+datatype: COMBO
+def_value: DC - 50 Ohm
+combo_def_1: DC - 50 Ohm
+combo_def_2: DC - 1 MOhm
+combo_def_3: AC - 1 MOhm
+cmd_def_1: DC50
+cmd_def_2: DC
+cmd_def_3: AC
+set_cmd: :CHAN3:INP
+get_cmd: :CHAN3:INP?
+section: Channels
+group: Channel 3
+
+[Ch3 - Bandwidth]
+datatype: COMBO
+def_value: OFF
+combo_def_1: OFF
+combo_def_2: 20 MHz
+combo_def_3: 200 MHz
+cmd_def_1: 0
+cmd_def_2: 20e6
+cmd_def_3: 200e6
+section: Channels
+group: Channel 3
+
+# Channel 4 - Parameters
+
+[Ch4 - Enabled]
+datatype: BOOLEAN
+def_value: 0
+set_cmd: :CHAN4:DISP
+get_cmd: :CHAN4:DISP?
+section: Channels
+group: Channel 4
+
+[Ch4 - Range]
+datatype: DOUBLE
+def_value: 1
+set_cmd: :CHAN4:RANG
+get_cmd: :CHAN4:RANG?
+section: Channels
+group: Channel 4
+
+[Ch4 - Offset]
+datatype: DOUBLE
+def_value: 0
+set_cmd: :CHAN4:OFFS
+get_cmd: :CHAN4:OFFS?
+section: Channels
+group: Channel 4
+
+[Ch4 - Coupling]
+datatype: COMBO
+def_value: DC - 50 Ohm
+combo_def_1: DC - 50 Ohm
+combo_def_2: DC - 1 MOhm
+combo_def_3: AC - 1 MOhm
+cmd_def_1: DC50
+cmd_def_2: DC
+cmd_def_3: AC
+set_cmd: :CHAN4:INP
+get_cmd: :CHAN4:INP?
+section: Channels
+group: Channel 4
+
+[Ch4 - Bandwidth]
+datatype: COMBO
+def_value: OFF
+combo_def_1: OFF
+combo_def_2: 20 MHz
+combo_def_3: 200 MHz
+cmd_def_1: 0
+cmd_def_2: 20e6
+cmd_def_3: 200e6
+section: Channels
+group: Channel 4
+
+######################
+# Readout
+######################
+
+[Ch1 - Data]
+datatype: VECTOR
+permission: READ
+x_name: Time
+x_unit: s
+show_in_measurement_dlg: True
+state_quant: Ch1 - Enabled
+state_value_1: 1
+
+[Ch2 - Data]
+datatype: VECTOR
+permission: READ
+x_name: Time
+x_unit: s
+show_in_measurement_dlg: True
+state_quant: Ch2 - Enabled
+state_value_1: 1
+
+[Ch3 - Data]
+datatype: VECTOR
+permission: READ
+x_name: Time
+x_unit: s
+show_in_measurement_dlg: True
+state_quant: Ch3 - Enabled
+state_value_1: 1
+
+[Ch4 - Data]
+datatype: VECTOR
+permission: READ
+x_name: Time
+x_unit: s
+show_in_measurement_dlg: True
+state_quant: Ch4 - Enabled
+state_value_1: 1

--- a/Keysight_S-Series_Oscilloscope/Keysight_S-Series_Oscilloscope.py
+++ b/Keysight_S-Series_Oscilloscope/Keysight_S-Series_Oscilloscope.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python
+
+import InstrumentDriver
+from VISA_Driver import VISA_Driver
+from InstrumentConfig import InstrumentQuantity
+import numpy as np
+
+class Error(Exception):
+    pass
+
+class Driver(VISA_Driver):
+
+    """ This class implements the Keysight N90xx instrument driver"""
+    def performOpen(self, options={}):
+        VISA_Driver.performOpen(self, options=options)
+        self.acquisitionsPerformed = 0
+
+    def performSetValue(self, quant, value, sweepRate=0.0, options={}):
+        """Perform the Set Value instrument operation. This function should return the actual value set by the instrument"""
+        try:
+            if quant.name in ('Trigger level',):
+                sourcename = self.getValue('Trigger source')
+                if sourcename[:7] == 'Channel':
+                    nChannel = int(sourcename[-1])
+                    cmdstring = ':TRIG:LEV CHAN{}, {}'.format(int(sourcename[-1]), value)
+                elif sourcename[:3] == 'AUX':
+                    cmdstring = ':TRIG:LEV AUX, {}'.format(value)
+                else:
+                    pass
+                self.writeAndLog(cmdstring)
+                return self.performGetValue(quant)
+            else:
+                # run standard VISA case 
+                value = VISA_Driver.performSetValue(self, quant, value, sweepRate, options)
+                return self.performGetValue(quant)
+        except Exception as e:
+            msg = str(e)
+            raise InstrumentDriver.CommunicationError(msg)
+
+
+    def performGetValue(self, quant, options={}):
+        """Perform the Get Value instrument operation"""
+        # check type of quantity
+        if quant.name in ('Ch1 - Data', 'Ch2 - Data', 'Ch3 - Data', 'Ch4 - Data'):
+            # traces, get channel
+            channel = int(quant.name[2])
+            if self.isConfigUpdated():
+                self.acquireData()
+                self.acquisitionsPerformed = 0
+
+            # check if channel is on
+            if self.getValue('Ch%d - Enabled' % channel):
+
+                nTotalAcquisitions = self.nEnabledChannels() # returns with the total number of enabled channels
+
+                # Acquire data *once*. Prevents long averaging scans from happening sequentially for each oscilloscope channel.
+                if self.acquisitionsPerformed == 0:
+                    self.acquireData()
+                    if nTotalAcquisitions > 1:
+                        self.acquisitionsPerformed = self.acquisitionsPerformed + 1
+                elif (self.acquisitionsPerformed == (nTotalAcquisitions - 1)):
+                    self.acquisitionsPerformed = 0
+                else:
+                    self.acquisitionsPerformed = self.acquisitionsPerformed + 1
+
+                # the following code obtains the waveforms from memory.
+
+                self.writeAndLog(':WAV:SOUR CHAN{}'.format(channel)) # Identifies the channel that we read out
+
+                self.write(':WAV:DATA?', bCheckError=False) # tells the oscilloscope to send the data to the computer
+                sData = self.read() # tells the computer to read its buffer; data is a string '1.059E-3, 2.032E-3, ... '
+                lData = sData.split(',') # data is a list of strings: ['1.059E-3', '2.032E-3', ... ]
+                vData = np.array(lData[:-1], dtype = float) # data is a numpy array of floats; lData[-1] is a newline character
+
+                dt = float(self.ask(':WAV:XINC?'))
+                value = quant.getTraceDict(vData, dt = dt)
+            else:
+                # not enabled, return empty array
+                value = quant.getTraceDict([])
+        elif quant.name in ('Trigger level',):
+            sourcename = self.getValue('Trigger source')
+            if sourcename[:7] == 'Channel':
+                nChannel = int(sourcename[-1])
+                cmdstring = ':TRIG:LEV? CHAN{}'.format(int(sourcename[-1]))
+                value = self.askAndLog(cmdstring, bCheckError = False)
+            elif sourcename[:3] == 'AUX':
+                cmdstring = ':TRIG:LEV? AUX'
+                value = self.askAndLog(cmdstring, bCheckError = False)
+            else:
+                raise
+        elif quant.name in ('Ch1 - Enabled', 'Ch2 - Enabled', 'Ch3 - Enabled', 'Ch4 - Enabled'):
+            value = VISA_Driver.performGetValue(self, quant, options)
+            BW = self.readValueFromOther('Bandwidth')
+            self.setValue('Bandwidth', BW)
+            samplePoints = self.readValueFromOther('Sample points')
+            self.setValue('Sample points', samplePoints)
+            sampleRate = self.readValueFromOther('Sample rate')
+            self.setValue('Sample rate', sampleRate)
+            timeRange = self.readValueFromOther('Time range')
+            self.setValue('Time range', timeRange)
+        elif quant.name in ('Sample rate',):
+            value = VISA_Driver.performGetValue(self, quant, options)
+            BW = self.readValueFromOther('Bandwidth')
+            self.setValue('Bandwidth', BW)
+        else:
+            # for all other cases, call VISA driver
+            value = VISA_Driver.performGetValue(self, quant, options)
+        return value
+
+    def nEnabledChannels(self):
+        count = 0
+        for channel in range(1,5):
+            if self.getValue('Ch{} - Enabled'.format(channel)):
+                count = count + 1
+        return count
+
+    def acquireData(self):
+        self.writeAndLog('*CLS; :SYST:HEAD OFF; :ACQ:MODE RTIME; :ACQ:COMP 100; :WAV:FORM ASC')
+        for channelstr in ('Ch1 - Data', 'Ch2 - Data', 'Ch3 - Data', 'Ch4 - Data'):
+            channel = int(channelstr[2])
+            self.writeAndLog(':WMEM{}:CLE'.format(channel))
+        bFinished = self.askAndLog(':DIG; *OPC?')
+
+
+if __name__ == '__main__':
+    pass


### PR DESCRIPTION
This driver uses a blocking command to simultaneously acquire on all channels. Each channel is then read from memory without performing a subsequent acquisition.

The driver attempts to update all of the relevant dependencies, e.g. between sample rate and bandwidth, immediately after the performSetValue command.