### PR TITLE
Start Gaussian pulses at zero amplitude

### DIFF
--- a/MultiQubit_PulseGenerator/MultiQubit_PulseGenerator.ini
+++ b/MultiQubit_PulseGenerator/MultiQubit_PulseGenerator.ini
@@ -12,7 +12,7 @@ version: 1.0
 # or leave it blank for any standard driver based on the built-in VISA interface.
 driver_path: MultiQubit_PulseGenerator
 
-# Define that this driver is a signal generator without hardware communication 
+# Define that this driver is a signal generator without hardware communication
 signal_generator: True
 signal_analyzer: True
 
@@ -36,7 +36,7 @@ signal_analyzer: True
 #   state_value_2: Value of "state_quant" for which the control is visible
 #   ...
 #   state_value_n: Value of "state_quant" for which the control is visible
-#   permission:    Sets read/writability, options are BOTH, READ, WRITE or NONE. Default is BOTH 
+#   permission:    Sets read/writability, options are BOTH, READ, WRITE or NONE. Default is BOTH
 #   group:         Name of the group where the control belongs.
 #   section:       Name of the section where the control belongs.
 
@@ -66,7 +66,7 @@ section: Sequence
 [Number of qubits]
 datatype: COMBO
 combo_def_1: One
-combo_def_2: Two 
+combo_def_2: Two
 combo_def_3: Three
 combo_def_4: Four
 combo_def_5: Five
@@ -229,7 +229,7 @@ show_in_measurement_dlg: True
 datatype: DOUBLE
 def_value: 0
 group: 1QB Randomized Benchmarking
-tooltip: Randomize gate sequence only if "Randomize" value changes or "Number of Cliffords" changes 
+tooltip: Randomize gate sequence only if "Randomize" value changes or "Number of Cliffords" changes
 section: Sequence
 state_quant: Sequence
 state_value_1: 1QB Randomized Benchmarking
@@ -319,6 +319,14 @@ section: 1-QB gates
 [Truncation range]
 datatype: DOUBLE
 def_value: 3
+state_quant: Pulse type
+state_value_1: Gaussian
+group: Pulse settings
+section: 1-QB gates
+
+[Start at zero]
+datatype: BOOLEAN
+def_value: 0
 state_quant: Pulse type
 state_value_1: Gaussian
 group: Pulse settings
@@ -756,7 +764,7 @@ label: Pulse type
 datatype: COMBO
 combo_def_1: Gaussian
 combo_def_2: Square
-combo_def_3: Ramp   
+combo_def_3: Ramp
 combo_def_4: CZ
 def_value: CZ
 group: 2-QB pulses
@@ -766,6 +774,15 @@ section: 2-QB gates
 label: Truncation range
 datatype: DOUBLE
 def_value: 3
+state_quant: Pulse type, 2QB
+state_value: Gaussian
+group: 2-QB pulses
+section: 2-QB gates
+
+[Start at zero, 2QB]
+label: Start at zero
+datatype: BOOLEAN
+def_value: 0
 state_quant: Pulse type, 2QB
 state_value: Gaussian
 group: 2-QB pulses
@@ -893,7 +910,7 @@ group: 2-QB pulse #12
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
 state_value_1: One
-state_value_2: Two 
+state_value_2: Two
 state_value_3: Three
 state_value_4: Four
 [L2, 2QB #12]
@@ -903,7 +920,7 @@ def_value: 0
 group: 2-QB pulse #12
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
-state_value_1: Two 
+state_value_1: Two
 state_value_2: Three
 state_value_3: Four
 [L3, 2QB #12]
@@ -999,7 +1016,7 @@ group: 2-QB pulse #23
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
 state_value_1: One
-state_value_2: Two 
+state_value_2: Two
 state_value_3: Three
 state_value_4: Four
 [L2, 2QB #23]
@@ -1009,7 +1026,7 @@ def_value: 0
 group: 2-QB pulse #23
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
-state_value_1: Two 
+state_value_1: Two
 state_value_2: Three
 state_value_3: Four
 [L3, 2QB #23]
@@ -1105,7 +1122,7 @@ group: 2-QB pulse #34
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
 state_value_1: One
-state_value_2: Two 
+state_value_2: Two
 state_value_3: Three
 state_value_4: Four
 [L2, 2QB #34]
@@ -1115,7 +1132,7 @@ def_value: 0
 group: 2-QB pulse #34
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
-state_value_1: Two 
+state_value_1: Two
 state_value_2: Three
 state_value_3: Four
 [L3, 2QB #34]
@@ -1211,7 +1228,7 @@ group: 2-QB pulse #45
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
 state_value_1: One
-state_value_2: Two 
+state_value_2: Two
 state_value_3: Three
 state_value_4: Four
 [L2, 2QB #45]
@@ -1221,7 +1238,7 @@ def_value: 0
 group: 2-QB pulse #45
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
-state_value_1: Two 
+state_value_1: Two
 state_value_2: Three
 state_value_3: Four
 [L3, 2QB #45]
@@ -1317,7 +1334,7 @@ group: 2-QB pulse #56
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
 state_value_1: One
-state_value_2: Two 
+state_value_2: Two
 state_value_3: Three
 state_value_4: Four
 [L2, 2QB #56]
@@ -1327,7 +1344,7 @@ def_value: 0
 group: 2-QB pulse #56
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
-state_value_1: Two 
+state_value_1: Two
 state_value_2: Three
 state_value_3: Four
 [L3, 2QB #56]
@@ -1423,7 +1440,7 @@ group: 2-QB pulse #67
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
 state_value_1: One
-state_value_2: Two 
+state_value_2: Two
 state_value_3: Three
 state_value_4: Four
 [L2, 2QB #67]
@@ -1433,7 +1450,7 @@ def_value: 0
 group: 2-QB pulse #67
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
-state_value_1: Two 
+state_value_1: Two
 state_value_2: Three
 state_value_3: Four
 [L3, 2QB #67]
@@ -1529,7 +1546,7 @@ group: 2-QB pulse #78
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
 state_value_1: One
-state_value_2: Two 
+state_value_2: Two
 state_value_3: Three
 state_value_4: Four
 [L2, 2QB #78]
@@ -1539,7 +1556,7 @@ def_value: 0
 group: 2-QB pulse #78
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
-state_value_1: Two 
+state_value_1: Two
 state_value_2: Three
 state_value_3: Four
 [L3, 2QB #78]
@@ -1635,7 +1652,7 @@ group: 2-QB pulse #89
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
 state_value_1: One
-state_value_2: Two 
+state_value_2: Two
 state_value_3: Three
 state_value_4: Four
 [L2, 2QB #89]
@@ -1645,7 +1662,7 @@ def_value: 0
 group: 2-QB pulse #89
 section: 2-QB gates
 state_quant: Fourier terms, 2QB
-state_value_1: Two 
+state_value_1: Two
 state_value_2: Three
 state_value_3: Four
 [L3, 2QB #89]
@@ -1893,7 +1910,7 @@ group: Readout
 section: Readout
 [Match main sequence waveform size]
 datatype: BOOLEAN
-tooltip: If checked, the readout waveform will have the same number of point as the main pulse waveforms 
+tooltip: If checked, the readout waveform will have the same number of point as the main pulse waveforms
 def_value: 0
 group: Readout
 section: Readout
@@ -1953,7 +1970,7 @@ group: Readout
 section: Readout
 [Distribute readout phases]
 datatype: BOOLEAN
-tooltip: If checked, the readout tone phases will be distributed to avoid large peak-to-peak voltages 
+tooltip: If checked, the readout tone phases will be distributed to avoid large peak-to-peak voltages
 def_value: 0
 group: Readout
 section: Readout
@@ -1965,7 +1982,7 @@ group: Readout
 section: Readout
 [Predistort readout waveform]
 datatype: BOOLEAN
-tooltip: If checked, the readout waveform will be predistorted to increase the rise time 
+tooltip: If checked, the readout waveform will be predistorted to increase the rise time
 def_value: 0
 group: Readout predistortion
 section: Readout
@@ -1978,11 +1995,11 @@ state_quant: Predistort readout waveform
 state_value: 1
 group: Readout predistortion
 section: Readout
-[Target rise time]	
+[Target rise time]
 datatype: DOUBLE
 def_value: 50E-9
 unit: s
-tooltip: Intended resonator ring-up time 
+tooltip: Intended resonator ring-up time
 state_quant: Predistort readout waveform
 state_value: 1
 group: Readout predistortion
@@ -2081,11 +2098,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 state_value_7: Three
 state_value_8: Two
 section: Output
@@ -2098,11 +2115,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 state_value_7: Three
 state_value_8: Two
 section: Output
@@ -2115,11 +2132,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 state_value_7: Three
 state_value_8: Two
 section: Output
@@ -2132,11 +2149,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 state_value_7: Three
 state_value_8: Two
 section: Output
@@ -2150,11 +2167,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 state_value_7: Three
 section: Output
 [Trace - Q3]
@@ -2166,11 +2183,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 state_value_7: Three
 section: Output
 [Trace - G3]
@@ -2182,11 +2199,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 state_value_7: Three
 section: Output
 [Trace - Z3]
@@ -2198,11 +2215,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 state_value_7: Three
 section: Output
 
@@ -2215,11 +2232,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 section: Output
 [Trace - Q4]
 unit: V
@@ -2230,11 +2247,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 section: Output
 [Trace - G4]
 unit: V
@@ -2245,11 +2262,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 section: Output
 [Trace - Z4]
 unit: V
@@ -2260,11 +2277,11 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 section: Output
 
 [Trace - I5]
@@ -2276,7 +2293,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
@@ -2290,7 +2307,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
@@ -2304,7 +2321,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
@@ -2318,7 +2335,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
@@ -2333,7 +2350,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 section: Output
@@ -2346,7 +2363,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 section: Output
@@ -2359,7 +2376,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 section: Output
@@ -2372,7 +2389,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 section: Output
@@ -2386,7 +2403,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 section: Output
 [Trace - Q7]
@@ -2398,7 +2415,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 section: Output
 [Trace - G7]
@@ -2410,7 +2427,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 section: Output
 [Trace - Z7]
@@ -2422,7 +2439,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 section: Output
 
@@ -2435,7 +2452,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 section: Output
 [Trace - Q8]
 unit: V
@@ -2446,7 +2463,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 section: Output
 [Trace - G8]
 unit: V
@@ -2457,7 +2474,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 section: Output
 [Trace - Z8]
 unit: V
@@ -2468,7 +2485,7 @@ permission: READ
 group: Traces
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 section: Output
 
 [Trace - I9]
@@ -2605,11 +2622,11 @@ permission: READ
 group: Demodulation
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 state_value_7: Three
 state_value_8: Two
 section: Demodulation
@@ -2620,11 +2637,11 @@ permission: READ
 group: Demodulation
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 state_value_7: Three
 section: Demodulation
 [Voltage, QB4]
@@ -2634,11 +2651,11 @@ permission: READ
 group: Demodulation
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
-state_value_6: Four 
+state_value_6: Four
 section: Demodulation
 [Voltage, QB5]
 unit: V
@@ -2647,7 +2664,7 @@ permission: READ
 group: Demodulation
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 state_value_5: Five
@@ -2659,7 +2676,7 @@ permission: READ
 group: Demodulation
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 state_value_4: Six
 section: Demodulation
@@ -2670,7 +2687,7 @@ permission: READ
 group: Demodulation
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 state_value_3: Seven
 section: Demodulation
 [Voltage, QB8]
@@ -2680,7 +2697,7 @@ permission: READ
 group: Demodulation
 state_quant: Number of qubits
 state_value_1: Nine
-state_value_2: Eight 
+state_value_2: Eight
 section: Demodulation
 [Voltage, QB9]
 unit: V

--- a/MultiQubit_PulseGenerator/pulse.py
+++ b/MultiQubit_PulseGenerator/pulse.py
@@ -19,7 +19,7 @@ class Pulse(object):
         Pulse amplitude.
 
     width : float
-        Pulse rise/fall duration.  The parameter is defined so that the pulse 
+        Pulse rise/fall duration.  The parameter is defined so that the pulse
         gives the same integrated area as a square pulse with the given width.
 
     plateau : float
@@ -43,6 +43,9 @@ class Pulse(object):
     truncation_range : float
         Truncation range, measured in units of the `width` parameter.
 
+    start_at_zero : bool
+        If True, forces the pulse to start at zero amplitude
+
     z_pulse : bool
         If True, the pulse will be used for qubit Z control.
 
@@ -51,7 +54,7 @@ class Pulse(object):
     def __init__(self,F_Terms=1,Coupling=20E6,Offset=300E6,Lcoeff = np.array([0.3]),dfdV=0.5E9,period_2qb=50E-9, amplitude=0.5, width=10E-9, plateau=0.0,
                  frequency=0.0, phase=0.0, shape=PulseShape.GAUSSIAN,
                  use_drag=False, drag_coefficient=0.0, truncation_range=5.0,
-                 z_pulse=False):
+                 z_pulse=False, start_at_zero=False):
         # set variables
         self.amplitude = amplitude
         self.width = width
@@ -59,11 +62,12 @@ class Pulse(object):
         self.frequency = frequency
         self.phase = phase
         self.shape = shape
-        self.use_drag = use_drag    
+        self.use_drag = use_drag
         self.drag_coefficient = drag_coefficient
         self.truncation_range = truncation_range
         self.z_pulse = z_pulse
-        
+        self.start_at_zero = start_at_zero
+
         # For 2-qubit gates
         self.F_Terms = F_Terms
         self.Coupling = Coupling
@@ -155,6 +159,9 @@ class Pulse(object):
                         np.exp(-(t - (t0 + self.plateau / 2))**2 / (2 * std**2))
                     )
             values = values*self.amplitude
+            if self.start_at_zero:
+                values = values - values.min()
+                values = values/values.max()*self.amplitude
 
         elif self.shape == PulseShape.CZ:
             # notation and calculations are based on the Paper "Fast adiabatic qubit gates using only σ_z control" PRA 90, 022307 (2014)
@@ -186,7 +193,7 @@ class Pulse(object):
                 if i > 0 :
                     t_tau[i] = np.trapz(np.sin(theta_tau[0:i]),x=tau[0:i])
 
-            # Adding frequency pulse to waveform using 2Q pulse period. Padding waveform with theta_i if pulse width is less than 2Q pulse period. 
+            # Adding frequency pulse to waveform using 2Q pulse period. Padding waveform with theta_i if pulse width is less than 2Q pulse period.
             # Plateau is added as an extra extension of theta_f in the middle of the pulse.
             theta_t = np.ones(len(t))*theta_i
             for i in range(len(t)):
@@ -206,4 +213,3 @@ class Pulse(object):
 
 if __name__ == '__main__':
     pass
-

--- a/MultiQubit_PulseGenerator/sequence.py
+++ b/MultiQubit_PulseGenerator/sequence.py
@@ -690,6 +690,7 @@ class Sequence(object):
             # global parameters
             pulse.shape = PulseShape(config.get('Pulse type'))
             pulse.truncation_range = config.get('Truncation range')
+            pulse.start_at_zero = config.get('Start at zero')
             pulse.use_drag = config.get('Use DRAG')
             # pulse shape
             if config.get('Uniform pulse shape'):
@@ -720,7 +721,7 @@ class Sequence(object):
                     pulse.plateau = config.get('Plateau, 2QB')
 
                 # Get Fourier values
-                if d[config.get('Fourier terms, 2QB')] == 4 : 
+                if d[config.get('Fourier terms, 2QB')] == 4 :
                     pulse.Lcoeff = np.array([config.get('L1, 2QB' + s),config.get('L2, 2QB' + s),config.get('L3, 2QB' + s),config.get('L4, 2QB' + s)])
                 elif d[config.get('Fourier terms, 2QB')] == 3 :
                     pulse.Lcoeff = np.array([config.get('L1, 2QB' + s),config.get('L2, 2QB' + s),config.get('L3, 2QB' + s)])
@@ -736,6 +737,7 @@ class Sequence(object):
 
             else:
                 pulse.truncation_range = config.get('Truncation range, 2QB')
+                pulse.start_at_zero = config.get('Start at zero, 2QB')
                 # pulse shape
                 if config.get('Uniform 2QB pulses'):
                     pulse.width = config.get('Width, 2QB')

--- a/SingleQubit_PulseGenerator/SingleQubit_PulseGenerator.ini
+++ b/SingleQubit_PulseGenerator/SingleQubit_PulseGenerator.ini
@@ -12,7 +12,7 @@ version: 1.0
 # or leave it blank for any standard driver based on the built-in VISA interface.
 driver_path: SingleQubit_PulseGenerator
 
-# Define that this driver is a signal generator without hardware communication 
+# Define that this driver is a signal generator without hardware communication
 signal_generator: True
 
 
@@ -35,7 +35,7 @@ signal_generator: True
 #   state_value_2: Value of "state_quant" for which the control is visible
 #   ...
 #   state_value_n: Value of "state_quant" for which the control is visible
-#   permission:    Sets read/writability, options are BOTH, READ, WRITE or NONE. Default is BOTH 
+#   permission:    Sets read/writability, options are BOTH, READ, WRITE or NONE. Default is BOTH
 #   group:         Name of the group where the control belongs.
 #   section:       Name of the section where the control belongs.
 
@@ -43,7 +43,7 @@ signal_generator: True
 [Sequence]
 datatype: COMBO
 combo_def_1: Rabi
-combo_def_2: CP/CPMG 
+combo_def_2: CP/CPMG
 combo_def_3: Pulse train
 combo_def_4: Generic sequence
 group: Waveform
@@ -89,7 +89,7 @@ section: Waveform
 [Number of outputs]
 datatype: COMBO
 combo_def_1: One
-combo_def_2: Two 
+combo_def_2: Two
 combo_def_3: Three
 combo_def_4: Four
 group: Waveform
@@ -149,6 +149,14 @@ def_value: 5
 group: Pulse settings
 section: Pulses
 
+[Start at zero]
+datatype: BOOLEAN
+def_value: 0
+state_quant: Pulse type
+state_value_1: Gaussian
+group: Pulse settings
+section: Pulses
+
 [Edge-to-edge pulses]
 datatype: BOOLEAN
 def_value: 1
@@ -175,7 +183,7 @@ def_value: False
 group: Pulse settings
 section: Pulses
 
-[DRAG scaling] 
+[DRAG scaling]
 datatype: DOUBLE
 unit: s
 def_value: .25E-9
@@ -250,12 +258,12 @@ section: Pulses
 label: Output
 datatype: COMBO
 combo_def_1: One
-combo_def_2: Two 
+combo_def_2: Two
 combo_def_3: Three
 combo_def_4: Four
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 group: Pulse #1
 section: Pulses
@@ -320,12 +328,12 @@ section: Pulses
 label: Output
 datatype: COMBO
 combo_def_1: One
-combo_def_2: Two 
+combo_def_2: Two
 combo_def_3: Three
 combo_def_4: Four
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 group: Pulse #2
 section: Pulses
@@ -389,12 +397,12 @@ section: Pulses
 label: Output
 datatype: COMBO
 combo_def_1: One
-combo_def_2: Two 
+combo_def_2: Two
 combo_def_3: Three
 combo_def_4: Four
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 group: Pulse #3
 section: Pulses
@@ -458,12 +466,12 @@ section: Pulses
 label: Output
 datatype: COMBO
 combo_def_1: One
-combo_def_2: Two 
+combo_def_2: Two
 combo_def_3: Three
 combo_def_4: Four
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 group: Pulse #4
 section: Pulses
@@ -527,12 +535,12 @@ section: Pulses
 label: Output
 datatype: COMBO
 combo_def_1: One
-combo_def_2: Two 
+combo_def_2: Two
 combo_def_3: Three
 combo_def_4: Four
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 group: Pulse #5
 section: Pulses
@@ -596,12 +604,12 @@ section: Pulses
 label: Output
 datatype: COMBO
 combo_def_1: One
-combo_def_2: Two 
+combo_def_2: Two
 combo_def_3: Three
 combo_def_4: Four
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 group: Pulse #6
 section: Pulses
@@ -665,12 +673,12 @@ section: Pulses
 label: Output
 datatype: COMBO
 combo_def_1: One
-combo_def_2: Two 
+combo_def_2: Two
 combo_def_3: Three
 combo_def_4: Four
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 group: Pulse #7
 section: Pulses
@@ -734,12 +742,12 @@ section: Pulses
 label: Output
 datatype: COMBO
 combo_def_1: One
-combo_def_2: Two 
+combo_def_2: Two
 combo_def_3: Three
 combo_def_4: Four
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 group: Pulse #8
 section: Pulses
@@ -998,7 +1006,7 @@ permission: READ
 group: Traces
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 section: Output
 [Trace - Q2]
@@ -1010,7 +1018,7 @@ permission: READ
 group: Traces
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 section: Output
 [Trace - Gate2]
@@ -1022,7 +1030,7 @@ permission: READ
 group: Traces
 state_quant: Number of outputs
 state_value_1: Two
-state_value_2: Three 
+state_value_2: Three
 state_value_3: Four
 section: Output
 
@@ -1034,7 +1042,7 @@ datatype: VECTOR
 permission: READ
 group: Traces
 state_quant: Number of outputs
-state_value_1: Three 
+state_value_1: Three
 state_value_2: Four
 section: Output
 [Trace - Q3]
@@ -1045,7 +1053,7 @@ datatype: VECTOR
 permission: READ
 group: Traces
 state_quant: Number of outputs
-state_value_1: Three 
+state_value_1: Three
 state_value_2: Four
 section: Output
 [Trace - Gate3]
@@ -1056,7 +1064,7 @@ datatype: VECTOR
 permission: READ
 group: Traces
 state_quant: Number of outputs
-state_value_1: Three 
+state_value_1: Three
 state_value_2: Four
 section: Output
 
@@ -1100,4 +1108,3 @@ permission: READ
 group: Traces
 section: Output
 show_in_measurement_dlg: True
-


### PR DESCRIPTION
Solves #57 
Added options to start at zero for both 1 and 2 qubit gates with Gaussian pulses. The offset is subtracted and the amplitude is then rescaled so that the amplitude is not affected.

Looks like my editor removed all (unnecessary) trailing whitespaces, I hope this is ok.