### PR TITLE
fix issues on Agilent SA driver and multiqubit driver

### DIFF
--- a/Agilent_SpectrumAnalyzer/Agilent_SpectrumAnalyzer.ini
+++ b/Agilent_SpectrumAnalyzer/Agilent_SpectrumAnalyzer.ini
@@ -62,6 +62,7 @@ final:
 
 # List of models supported by this driver
 model_str_1: E44xx
+model_str_2: N90xx
 
 # Check instrument model id at startup (True or False). Default is False
 check_model: True
@@ -71,6 +72,7 @@ check_model: True
 
 # Valid model strings returned by the instrument. Default value = model_str
 model_id_1: Hewlett-Packard, E44
+model_id_2: Agilent Technologies,N90
 
 
 # Define quantities in sections. This list is a selection of allowed keywords,
@@ -189,19 +191,6 @@ group: Acquisition
 datatype: BOOLEAN
 def_value: False
 group: Acquisition
-
-[Output enabled]
-datatype: BOOLEAN
-def_value: False
-set_cmd: :OUTP
-group: Output
-
-[Output power]
-datatype: DOUBLE
-def_value: -30.0
-unit: dBm
-set_cmd: :SOUR:POW
-group: Output
 
 [Signal]
 x_name: Frequency

--- a/Agilent_SpectrumAnalyzer/Agilent_SpectrumAnalyzer.py
+++ b/Agilent_SpectrumAnalyzer/Agilent_SpectrumAnalyzer.py
@@ -90,7 +90,10 @@ class Driver(VISA_Driver):
             # get start/stop frequencies
             startFreq = self.readValueFromOther('Start frequency')
             stopFreq = self.readValueFromOther('Stop frequency')
-            sweepType = self.readValueFromOther('Sweep type')
+            if self.getModel() in ('N90xx'):
+                sweepType = 'Lin'
+            else:
+                sweepType = self.readValueFromOther('Sweep type')
             # if log scale, take log of start/stop frequencies
             if sweepType == 'Log':
                 startFreq = np.log10(startFreq)

--- a/MultiQubit_PulseGenerator/MultiQubit_PulseGenerator.ini
+++ b/MultiQubit_PulseGenerator/MultiQubit_PulseGenerator.ini
@@ -1867,12 +1867,6 @@ state_value_1: Five
 datatype: BOOLEAN
 group: Readout trig
 section: Readout
-[Readout delay]
-datatype: DOUBLE
-unit: s
-group: Readout trig
-section: Readout
-show_in_measurement_dlg: True
 [Readout trig amplitude]
 datatype: DOUBLE
 def_value: 1.0
@@ -1908,6 +1902,12 @@ def_value: 2E-6
 unit: s
 group: Readout
 section: Readout
+[Readout delay]
+datatype: DOUBLE
+unit: s
+group: Readout
+section: Readout
+show_in_measurement_dlg: True
 [Match main sequence waveform size]
 datatype: BOOLEAN
 tooltip: If checked, the readout waveform will have the same number of point as the main pulse waveforms
@@ -1999,7 +1999,7 @@ section: Readout
 [Readout IQ skew]
 label: IQ skew
 unit: deg
-tooltip: Readout IQ mixer phase skew 
+tooltip: Readout IQ mixer phase skew
 datatype: DOUBLE
 def_value: 0
 group: Readout

--- a/MultiQubit_PulseGenerator/MultiQubit_PulseGenerator.py
+++ b/MultiQubit_PulseGenerator/MultiQubit_PulseGenerator.py
@@ -5,6 +5,8 @@ from sequence_rb import SingleQubit_RB
 
 import importlib
 import numpy as np
+import os
+import sys
 
 # dictionary with built-in sequences
 SEQUENCES = {'Rabi': Rabi,
@@ -13,7 +15,7 @@ SEQUENCES = {'Rabi': Rabi,
              'C-phase Pulses': CZgates,
              'C-phase Echo': CZecho,
              '1QB Randomized Benchmarking': SingleQubit_RB,
-             'Custom': None}
+             'Custom': type(None)}
 
 
 class Driver(LabberDriver):
@@ -41,8 +43,12 @@ class Driver(LabberDriver):
                 if value == 'Custom':
                     # for custom python files
                     path = self.getValue('Custom Python file')
-                    mod = importlib.import_module(path)
-                    # the custom sequence class has to be named 'CustomSequence'
+                    (path, modName) = os.path.split(path)
+                    sys.path.append(path)
+                    modName = modName.split('.py')[0]  # strip suffix
+                    mod = importlib.import_module(modName)
+                    # the custom sequence class has to be named
+                    # 'CustomSequence'
                     self.sequence = mod.CustomSequence()
                 else:
                     # standard built-in sequence
@@ -51,7 +57,11 @@ class Driver(LabberDriver):
         elif (quant.name == 'Custom Python file' and
               self.getValue('Sequence') == 'Custom'):
             # for custom python files
-            mod = importlib.import_module(value)
+            path = self.getValue('Custom Python file')
+            (path, modName) = os.path.split(path)
+            modName = modName.split('.py')[0]  # strip suffix
+            sys.path.append(path)
+            mod = importlib.import_module(modName)
             # the custom sequence class has to be named 'CustomSequence'
             self.sequence = mod.CustomSequence()
         return value

--- a/MultiQubit_PulseGenerator/pulse.py
+++ b/MultiQubit_PulseGenerator/pulse.py
@@ -164,7 +164,7 @@ class Pulse(object):
                 values = values/values.max()*self.amplitude
 
         elif self.shape == PulseShape.CZ:
-            # notation and calculations are based on the Paper "Fast adiabatic qubit gates using only σ_z control" PRA 90, 022307 (2014)
+            # notation and calculations are based on the Paper "Fast adiabatic qubit gates using only sigma_z control" PRA 90, 022307 (2014)
 
             # Defining initial and final angles
             theta_i = np.arctan(self.Coupling/self.Offset) # Initial angle of on the |11>-|02> bloch sphere


### PR DESCRIPTION
Several commits, which I thought I would be able to separate into different pull requests. 

Commit 02673f0: Agilent SA driver did not support N90xx series; now it does
Commit 3e773b0: readout delay was in a funny place; now it's moved. Also removed a greek letter from a comment that was making python unhappy
Commit f64d159: custom driver read-in didn't work; now it does.  

I believe the MultiQubit_PulseGenerator folder must be on the path in order for custom drivers to work, which will not necessarily be the case for the general user. If you like I can have it added here as well.