### PR TITLE
multi-qubit 1QB RB - correct typo (I-gate)

### DIFF
--- a/MultiQubit_PulseGenerator/sequence_rb.py
+++ b/MultiQubit_PulseGenerator/sequence_rb.py
@@ -318,7 +318,7 @@ class SingleQubit_RB(Sequence):
         singleQ_gate =np.matrix([[1,0],[0,1]])
         for i in range(len(gate_seq)):
             if (gate_seq[i] == Gate.I):
-                singleQ_gate = np.matmul(np.matrix([[1,-1j],[-1j,1]])/np.sqrt(2), singleQ_gate)
+                pass
             elif (gate_seq[i] == Gate.X2p):
                 singleQ_gate = np.matmul(np.matrix([[1,-1j],[-1j,1]])/np.sqrt(2), singleQ_gate)
             elif (gate_seq[i] == Gate.X2m):


### PR DESCRIPTION
- correct typo in evaluate_seq(): I gate should be identity operation