### PR TITLE
Implementing the option to use cosine shaped pulses

### DIFF
--- a/MultiQubit_PulseGenerator/MultiQubit_PulseGenerator.ini
+++ b/MultiQubit_PulseGenerator/MultiQubit_PulseGenerator.ini
@@ -375,6 +375,7 @@ datatype: COMBO
 combo_def_1: Gaussian
 combo_def_2: Square
 combo_def_3: Ramp
+combo_def_4: Cosine
 group: Pulse settings
 section: 1-QB gates
 
@@ -828,6 +829,7 @@ combo_def_1: Gaussian
 combo_def_2: Square
 combo_def_3: Ramp
 combo_def_4: CZ
+combo_def_5: Cosine
 def_value: CZ
 group: 2-QB pulses
 section: 2-QB gates
@@ -904,6 +906,7 @@ state_quant: Pulse type, 2QB
 state_value_1: Gaussian
 state_value_2: Square
 state_value_3: Ramp
+state_value_4: Cosine
 show_in_measurement_dlg: True
 [Width, 2QB #12]
 label: Width
@@ -1016,6 +1019,7 @@ state_quant: Pulse type, 2QB
 state_value_1: Gaussian
 state_value_2: Square
 state_value_3: Ramp
+state_value_4: Cosine
 show_in_measurement_dlg: True
 [Width, 2QB #23]
 label: Width
@@ -1122,6 +1126,7 @@ state_quant: Pulse type, 2QB
 state_value_1: Gaussian
 state_value_2: Square
 state_value_3: Ramp
+state_value_4: Cosine
 show_in_measurement_dlg: True
 [Width, 2QB #34]
 label: Width
@@ -1228,6 +1233,7 @@ state_quant: Pulse type, 2QB
 state_value_1: Gaussian
 state_value_2: Square
 state_value_3: Ramp
+state_value_4: Cosine
 show_in_measurement_dlg: True
 [Width, 2QB #45]
 label: Width
@@ -1334,6 +1340,7 @@ state_quant: Pulse type, 2QB
 state_value_1: Gaussian
 state_value_2: Square
 state_value_3: Ramp
+state_value_4: Cosine
 show_in_measurement_dlg: True
 [Width, 2QB #56]
 label: Width
@@ -1440,6 +1447,7 @@ state_quant: Pulse type, 2QB
 state_value_1: Gaussian
 state_value_2: Square
 state_value_3: Ramp
+state_value_4: Cosine
 show_in_measurement_dlg: True
 [Width, 2QB #67]
 label: Width
@@ -1546,6 +1554,7 @@ state_quant: Pulse type, 2QB
 state_value_1: Gaussian
 state_value_2: Square
 state_value_3: Ramp
+state_value_4: Cosine
 show_in_measurement_dlg: True
 [Width, 2QB #78]
 label: Width
@@ -1652,6 +1661,7 @@ state_quant: Pulse type, 2QB
 state_value_1: Gaussian
 state_value_2: Square
 state_value_3: Ramp
+state_value_4: Cosine
 show_in_measurement_dlg: True
 [Width, 2QB #89]
 label: Width

--- a/MultiQubit_PulseGenerator/pulse.py
+++ b/MultiQubit_PulseGenerator/pulse.py
@@ -9,6 +9,7 @@ class PulseShape(Enum):
     SQUARE = 'Square'
     RAMP = 'Ramp'
     CZ = 'CZ'
+    COSINE = 'Cosine'
 
 class Pulse(object):
     """This class represents a pulse for qubit rotations.
@@ -87,6 +88,8 @@ class Pulse(object):
             duration = self.truncation_range * self.width + self.plateau
         elif self.shape == PulseShape.CZ:
             duration = self.width + self.plateau
+        elif self.shape == PulseShape.COSINE:
+            duration = self.width
         return duration
 
 
@@ -206,6 +209,10 @@ class Pulse(object):
 
             # Going from frequency to voltage assuming a linear dependence. Should be improved in the future.
             values = (self.Coupling/np.tan(theta_t))/self.dfdV - (self.Coupling/np.tan(theta_i))/self.dfdV
+
+        elif self.shape == PulseShape.COSINE:
+            tau = self.width
+            values = self.amplitude/2*(1-np.cos(2*np.pi*(t-t0+tau/2)/tau))
 
         # return pulse envelope
         return values

--- a/MultiQubit_PulseGenerator/sequence_builtin.py
+++ b/MultiQubit_PulseGenerator/sequence_builtin.py
@@ -40,9 +40,10 @@ class CPMG(Sequence):
         pi_to_q = config['Add pi pulses to Q']
         duration = config['Sequence duration']
         edge_to_edge = config['Edge-to-edge pulses']
-        if self.pulses_1qb[0].shape != PulseShape.SQUARE:  # non-square pulses
+        if self.pulses_1qb[0].shape == PulseShape.GAUSSIAN:
+            # Only gaussian pulses has a truncation range
             truncation = config['Truncation range']
-        else:  # square pulses
+        else:
             truncation = 0.0
         # center pulses in add_gates mode; ensure sufficient pulse spacing in CPMG mode
         t0 = self.first_delay + (self.pulses_1qb[0].width*2*truncation + self.pulses_1qb[0].plateau)*0.5


### PR DESCRIPTION
Cosine pulses have the nice property that they, and their first derivative, vanish at the pulse boundaries.
Added the option for both 1- and 2-qubit pulses.