### PR TITLE
Fixing CPMG bugs

### DIFF
--- a/MultiQubit_PulseGenerator/pulse.py
+++ b/MultiQubit_PulseGenerator/pulse.py
@@ -213,6 +213,10 @@ class Pulse(object):
         elif self.shape == PulseShape.COSINE:
             tau = self.width
             values = self.amplitude/2*(1-np.cos(2*np.pi*(t-t0+tau/2)/tau))
+            # Some rounding error in the number of sample can occur
+            # so make sure that any points outside the cosine is 0
+            values[t<(t0-tau/2)] = 0
+            values[t>(t0+tau/2)] = 0
 
         # return pulse envelope
         return values

--- a/MultiQubit_PulseGenerator/sequence_builtin.py
+++ b/MultiQubit_PulseGenerator/sequence_builtin.py
@@ -45,17 +45,21 @@ class CPMG(Sequence):
             truncation = config['Truncation range']
         else:
             truncation = 0.0
-        # center pulses in add_gates mode; ensure sufficient pulse spacing in CPMG mode
-        t0 = self.first_delay + self.pulses_1qb[0].total_duration()/2
+
+        max_width = np.max([p.total_duration() for p in self.pulses_1qb[:self.n_qubit]])
         # select type of refocusing pi pulse
         gate_pi = Gate.Yp if pi_to_q else Gate.Xp
 
         # add pulses for all active qubits
         for n, pulse in enumerate(self.pulses_1qb[:self.n_qubit]):
             # get effective pulse durations, for timing purposes
-            width = self.pulses_1qb[0].total_duration() if edge_to_edge else 0.0
+            width = self.pulses_1qb[n].total_duration() if edge_to_edge else 0.0
             pulse_total = width * (n_pulse + 1)
-
+            # center pulses in add_gates mode; ensure sufficient pulse spacing in CPMG mode
+            t0 = self.first_delay + self.pulses_1qb[n].total_duration()/2
+            # Align everything to the end of the last pulse of the one with the longest pulse width
+            t0 += (max_width - self.pulses_1qb[n].total_duration()) * (n_pulse + 1) if edge_to_edge else 0.0
+            t0 += (max_width - self.pulses_1qb[n].total_duration())
             # special case for -1 pulses => T1 experiment
             if n_pulse < 0:
                 # add pi pulse
@@ -84,6 +88,8 @@ class CPMG(Sequence):
             # add pi pulses, one by one
             for t in time_pi:
                 self.add_single_gate(n, gate_pi, t)
+
+
 
 
 

--- a/MultiQubit_PulseGenerator/sequence_builtin.py
+++ b/MultiQubit_PulseGenerator/sequence_builtin.py
@@ -46,14 +46,14 @@ class CPMG(Sequence):
         else:
             truncation = 0.0
         # center pulses in add_gates mode; ensure sufficient pulse spacing in CPMG mode
-        t0 = self.first_delay + (self.pulses_1qb[0].width*2*truncation + self.pulses_1qb[0].plateau)*0.5
+        t0 = self.first_delay + self.pulses_1qb[0].total_duration()/2
         # select type of refocusing pi pulse
         gate_pi = Gate.Yp if pi_to_q else Gate.Xp
 
         # add pulses for all active qubits
         for n, pulse in enumerate(self.pulses_1qb[:self.n_qubit]):
             # get effective pulse durations, for timing purposes
-            width = (2*truncation*pulse.width + pulse.plateau) if edge_to_edge else 0.0
+            width = self.pulses_1qb[0].total_duration() if edge_to_edge else 0.0
             pulse_total = width * (n_pulse + 1)
 
             # special case for -1 pulses => T1 experiment


### PR DESCRIPTION
The initial delay, and edge-to-edge spacing, for the CPMG sequence was only working with Gaussian pulses. By using the total_duration function, it now works for any pulse shape.

Also, if the pulse width for each qubit was different, the timing of the pulses were not correct. It has nog been fixed by aligning to the end of the final pi/2 pulse. 