### PR TITLE
Fixed bug with timing and length of I gates

### DIFF
--- a/MultiQubit_PulseGenerator/sequence.py
+++ b/MultiQubit_PulseGenerator/sequence.py
@@ -614,7 +614,7 @@ class SequenceToWaveforms:
         for step in self.sequences:
             for i, gate in enumerate(step.gates):
                 if gate is None:
-                    step.gates[i] = Gate.I.value
+                    step.gates[i] = IdentityGate(width=0)
 
     def _add_timings(self):
         for step in self.sequences:
@@ -628,6 +628,7 @@ class SequenceToWaveforms:
         for step in self.sequences:
             max_duration = -np.inf
             for q, g in enumerate(step.gates):
+                duration = 0
                 if isinstance(g, IdentityGate) and g.width is not None:
                     duration = g.width
                 else:
@@ -638,6 +639,8 @@ class SequenceToWaveforms:
                     max_duration = duration
             if step.t0 is None:
                 step.t_start = t_start + step.dt
+                if max_duration == 0:
+                    step.t_start -= step.dt
             else:
                 step.t_start = step.t0 - max_duration / 2
             step.t_start = self._round(step.t_start)


### PR DESCRIPTION
I'm pretty sure it was correct a while back, but now I had issues with VirtualZGates not taking 0 time for example. This should fix it. @mortenkjaergaard 